### PR TITLE
fix: correct typo in Get QuestDB page

### DIFF
--- a/src/pages/get-questdb.tsx
+++ b/src/pages/get-questdb.tsx
@@ -128,8 +128,7 @@ const GetQuestdbPage = () => {
 
     if (differenceInDays(new Date(), new Date(release.published_at)) < 31) {
       setReleaseDate(
-        "dd" ||
-          `${formatDistanceToNowStrict(new Date(release.published_at))} ago`,
+        `${formatDistanceToNowStrict(new Date(release.published_at))} ago`,
       )
     }
     setOs(getOs())


### PR DESCRIPTION
This fixes the release date being wrong on the questdb.io/get-questdb page.