### PR TITLE
fix(blog): add missing social meta tag to NYC taxis post

### DIFF
--- a/blog/2020-10-16-taxi-drivers-are-options-traders.md
+++ b/blog/2020-10-16-taxi-drivers-are-options-traders.md
@@ -8,6 +8,7 @@ tags: [deep-dive, story]
 description:
   An experiment analyzing the NYC taxi dataset through the eyes of an options
   trader.
+image: /img/blog/2020-10-16/banner.jpg
 ---
 
 <div


### PR DESCRIPTION
Add `og:image` tag for NYC taxis blog post.