### PR TITLE
fix(homepage): make the code element a block to prevent copy/paste overflow

### DIFF
--- a/src/css/jumbotron.module.css
+++ b/src/css/jumbotron.module.css
@@ -69,6 +69,10 @@
   overflow: initial;
 }
 
+.jumbotron__docker--code {
+  display: block;
+}
+
 .jumbotron__docker-icon {
   position: absolute;
   left: -25px;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -204,7 +204,7 @@ const Jumbotron = () => {
 
       <div className={jumbotronStyles.jumbotron__right}>
         <pre className={jumbotronStyles.jumbotron__docker}>
-          <code>
+          <code className={jumbotronStyles["jumbotron__docker--code"]}>
             {`docker pull questdb/questdb
 docker run -p 9000:9000 questdb/questdb`}
           </code>


### PR DESCRIPTION
A user reported that copying the `docker run -p...` line in the jumbotron after
a mouse selection produces an expected output when pasting:

`docker run -p 9000:9000 questdb/questdbDocker logo`

This PR makes the code element a block which prevent the mouse selection to
overflow to the icon.