### PR TITLE
docs: improve Kafka page

### DIFF
--- a/docs/third-party-tools/kafka.md
+++ b/docs/third-party-tools/kafka.md
@@ -1,6 +1,8 @@
 ---
 title: Kafka Connect
-description: JDBC driver support in QuestDB allows for ingesting messages from a Kafka topic via Kafka Connect.
+description:
+  JDBC driver support in QuestDB allows for ingesting messages from a Kafka
+  topic via Kafka Connect.
 ---
 
 Support for the JDBC driver means that data can easily be exported from a Kafka
@@ -104,6 +106,8 @@ bin/windows/kafka-console-producer.sh --topic example-topic --bootstrap-server l
 Paste this message (as one line) to create a table. The table name will be the
 topic used in the kafka-console-producer topic
 
+<!-- prettier-ignore-start -->
 ```json
 {    "schema": {        "type": "struct",        "fields": [            {                "type": "boolean",                "optional": false,               "field": "flag"            },            {                "type": "int8",                "optional": false,                "field": "id8"           },           {                "type": "int16",                "optional": false,                "field": "id16"            },            {                "type":"int32",                "optional": false,                "field": "id32"            },          {                  "type": "int64",               "optional": false,                "field": "id64"            },            {                "type": "float",                "optional": false,                "field": "idFloat"            },            {                "type": "double",                "optional": false,                "field": "idDouble"            },              {                "type": "string",                "optional": true,                "field": "msg"            }      ],        "optional": false,        "name": "msgschema"    },    "payload": {        "flag": false,        "id8": 222,        "id16": 222,        "id32": 222,        "id64": 222,        "idFloat": 222.0,        "idDouble": 333.0,               "msg": "hi"  }}
 ```
+<!-- prettier-ignore-end -->

--- a/docs/third-party-tools/kafka.md
+++ b/docs/third-party-tools/kafka.md
@@ -117,7 +117,7 @@ curl -G \
 The expected response based on the example JSON message published above will be
 the following:
 
-```
+```csv
 "flag","id8","id16","id32","id64","idFloat","idDouble","msg"
 false,-34,-34,222,222,222.0000,333.0,"hi"
 ```

--- a/docs/third-party-tools/kafka.md
+++ b/docs/third-party-tools/kafka.md
@@ -11,7 +11,7 @@ topic and ingested directly to QuestDB by means of Kafka Connect.
 This article assumes that users have successfully set up an installation of
 Kafka using the Confluent platform. Detailed instructions on how to get up and
 running can be found on the
-[confluent.io documentation](https://docs.confluent.io/platform/current/quickstart/index.html).
+[official documentation](https://docs.confluent.io/platform/current/quickstart/index.html).
 
 ## Prerequisites
 
@@ -32,13 +32,13 @@ Create a new PostgreSQL database:
 initdb -D "/path/to/db/pgdata"
 ```
 
-Start PostgreSQL
+Start PostgreSQL:
 
 ```shell
 pg_ctl -D "/path/to/db/pgdata" start
 ```
 
-Connect to PostgreSQL
+Connect to PostgreSQL:
 
 ```shell
 psql -d postgres
@@ -89,7 +89,7 @@ Start Kafka Connect:
 bin/connect-standalone.sh config/connect-standalone.properties config/connect-jdbc.properties
 ```
 
-## Publishing Messages
+## Publishing messages
 
 If no topics exist, one can be created using the following command:
 

--- a/docs/third-party-tools/kafka.md
+++ b/docs/third-party-tools/kafka.md
@@ -1,0 +1,109 @@
+---
+title: Kafka Connect
+description: JDBC driver support in QuestDB allows for ingesting messages from a Kafka topic via Kafka Connect.
+---
+
+Support for the JDBC driver means that data can easily be exported from a Kafka
+topic and ingested directly to QuestDB by means of Kafka Connect.
+
+This article assumes that users have successfully set up an installation of
+Kafka using the Confluent platform. Detailed instructions on how to get up and
+running can be found on the
+[confluent.io documentation](https://docs.confluent.io/platform/current/quickstart/index.html).
+
+## Prerequisites
+
+You will need the following:
+
+- PostgreSQL - [install](https://www.postgresql.org/download/)
+- Kafka using Confluent Platform -
+  [quickstart guide](https://docs.confluent.io/platform/current/quickstart/ce-quickstart.html#ce-quickstart)
+- Kafka Connect JDBC binary -
+  [install](https://docs.confluent.io/kafka-connect-jdbc/current/index.html)
+- PostgreSQL JDBC driver - [install](https://jdbc.postgresql.org/download.html)
+
+## Configure PostgreSQL
+
+Create a new PostgreSQL database:
+
+```shell
+initdb -D "/path/to/db/pgdata"
+```
+
+Start PostgreSQL
+
+```shell
+pg_ctl -D "/path/to/db/pgdata" start
+```
+
+Connect to PostgreSQL
+
+```shell
+psql -d postgres
+```
+
+## Configure Kafka
+
+Kafka should be installed with the Confluent Platform according to the
+[quickstart guide](https://docs.confluent.io/platform/current/quickstart/ce-quickstart.html#ce-quickstart).
+After installation is complete, users can add QuestDB as a
+[Sink Connector](https://docs.confluent.io/platform/current/connect/index.html#kafka-connect).
+The commands listed in this section must be run in the order listed below and
+from the Kafka home directory.
+
+Start the Kafka Zookeeper used to coordinate the server:
+
+```shell
+bin/zookeeper-server-start.sh  config/zookeeper.properties
+```
+
+Start a Kafka server:
+
+```shell
+bin/kafka-server-start.sh  config/server.properties
+```
+
+A `connect-jdbc.properties` file should be placed in the folder where Kafka is
+installed to pick up the JDBC connection settings. Create a new file in
+`./config/` named `connect-jdbc.properties`:
+
+```shell
+name=local-jdbc-sink
+connector.class=io.confluent.connect.jdbc.JdbcSinkConnector
+connection.url=jdbc:postgresql://127.0.0.1:8812/qdb?useSSL=false
+connection.user=admin
+connection.password=quest
+
+topics=quickstart-events
+insert.mode=insert
+dialect.name=PostgreSqlDatabaseDialect
+pk.mode=none
+auto.create=true
+```
+
+Start Kafka Connect:
+
+```shell
+bin/connect-standalone.sh config/connect-standalone.properties config/connect-jdbc.properties
+```
+
+## Publishing Messages
+
+If no topics exist, one can be created using the following command:
+
+```shell
+bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9099
+```
+
+At this point, a message can be published:
+
+```shell
+bin/windows/kafka-console-producer.sh --topic example-topic --bootstrap-server localhost:9092
+```
+
+Paste this message (as one line) to create a table. The table name will be the
+topic used in the kafka-console-producer topic
+
+```json
+{    "schema": {        "type": "struct",        "fields": [            {                "type": "boolean",                "optional": false,               "field": "flag"            },            {                "type": "int8",                "optional": false,                "field": "id8"           },           {                "type": "int16",                "optional": false,                "field": "id16"            },            {                "type":"int32",                "optional": false,                "field": "id32"            },          {                  "type": "int64",               "optional": false,                "field": "id64"            },            {                "type": "float",                "optional": false,                "field": "idFloat"            },            {                "type": "double",                "optional": false,                "field": "idDouble"            },              {                "type": "string",                "optional": true,                "field": "msg"            }      ],        "optional": false,        "name": "msgschema"    },    "payload": {        "flag": false,        "id8": 222,        "id16": 222,        "id32": 222,        "id64": 222,        "idFloat": 222.0,        "idDouble": 333.0,               "msg": "hi"  }}
+```

--- a/docs/third-party-tools/kafka.md
+++ b/docs/third-party-tools/kafka.md
@@ -92,7 +92,7 @@ bin/connect-standalone.sh config/connect-standalone.properties config/connect-jd
 If no topics exist, one can be created using the following command:
 
 ```shell
-bin/kafka-topics.sh --create --topic quickstart-events --bootstrap-server localhost:9099
+bin/kafka-topics.sh --create --topic example-topic --bootstrap-server localhost:9092
 ```
 
 At this point, a message can be published:

--- a/docs/third-party-tools/kafka.md
+++ b/docs/third-party-tools/kafka.md
@@ -9,49 +9,59 @@ Support for the JDBC driver means that data can easily be exported from a Kafka
 topic and ingested directly to QuestDB by means of Kafka Connect.
 
 This article assumes that users have successfully set up an installation of
-Kafka using the Confluent platform. Detailed instructions on how to get up and
-running can be found on the
-[official documentation](https://docs.confluent.io/platform/current/quickstart/index.html).
+Kafka and are ready to start exporting messages to QuestDB.
 
 ## Prerequisites
 
 You will need the following:
 
-- PostgreSQL - [install](https://www.postgresql.org/download/)
-- Kafka using Confluent Platform -
-  [quickstart guide](https://docs.confluent.io/platform/current/quickstart/ce-quickstart.html#ce-quickstart)
-- Kafka Connect JDBC binary -
-  [install](https://docs.confluent.io/kafka-connect-jdbc/current/index.html)
-- PostgreSQL JDBC driver - [install](https://jdbc.postgresql.org/download.html)
-
-## Configure PostgreSQL
-
-Create a new PostgreSQL database:
-
-```shell
-initdb -D "/path/to/db/pgdata"
-```
-
-Start PostgreSQL:
-
-```shell
-pg_ctl -D "/path/to/db/pgdata" start
-```
-
-Connect to PostgreSQL:
-
-```shell
-psql -d postgres
-```
+- PostgreSQL
+- Kafka
+- A running QuestDB instance
 
 ## Configure Kafka
 
-Kafka should be installed with the Confluent Platform according to the
-[quickstart guide](https://docs.confluent.io/platform/current/quickstart/ce-quickstart.html#ce-quickstart).
-After installation is complete, users can add QuestDB as a
-[Sink Connector](https://docs.confluent.io/platform/current/connect/index.html#kafka-connect).
-The commands listed in this section must be run in the order listed below and
-from the Kafka home directory.
+The following binaries must be available to Kafka:
+
+- Kafka Connect JDBC binary
+- PostgreSQL JDBC driver
+
+To download these files, visit the
+[Kafka Connect JDBC](https://www.confluent.io/hub/confluentinc/kafka-connect-jdbc)
+page and click the Download button in the **Download installation** section.
+Unzip the contents of the downloaded archive and copy the required `.jar` files
+to the location of the Kafka `libs` directory:
+
+```shell
+unzip confluentinc-kafka-connect-jdbc-10.0.1.zip
+cd confluentinc-kafka-connect-jdbc-10.0.1
+cp kafka-connect-jdbc-10.0.1.jar /path/to/kafka_2.13-2.6.0/libs
+cp postgresql-42.2.10.jar /path/to/kafka_2.13-2.6.0/libs
+```
+
+A configuration file `config/connect-jdbc.properties` must be created for
+standalone mode. Ensure that the Postgres connection URL matches the destination
+QuestDB instance. In this configuration file, a topic or list of topics can be
+specified under the `topics={mytopic}` key.
+
+```
+name=local-jdbc-sink
+connector.class=io.confluent.connect.jdbc.JdbcSinkConnector
+connection.url=jdbc:postgresql://127.0.0.1:8812/qdb?useSSL=false
+connection.user=admin
+connection.password=quest
+
+topics=example-events
+insert.mode=insert
+dialect.name=PostgreSqlDatabaseDialect
+pk.mode=none
+auto.create=true
+```
+
+## Starting Kafka
+
+The commands listed in this section must be run from the Kafka home directory
+and in the order shown below.
 
 Start the Kafka Zookeeper used to coordinate the server:
 
@@ -65,24 +75,6 @@ Start a Kafka server:
 bin/kafka-server-start.sh  config/server.properties
 ```
 
-A `connect-jdbc.properties` file should be placed in the folder where Kafka is
-installed to pick up the JDBC connection settings. Create a new file in
-`./config/` named `connect-jdbc.properties`:
-
-```shell
-name=local-jdbc-sink
-connector.class=io.confluent.connect.jdbc.JdbcSinkConnector
-connection.url=jdbc:postgresql://127.0.0.1:8812/qdb?useSSL=false
-connection.user=admin
-connection.password=quest
-
-topics=quickstart-events
-insert.mode=insert
-dialect.name=PostgreSqlDatabaseDialect
-pk.mode=none
-auto.create=true
-```
-
 Start Kafka Connect:
 
 ```shell
@@ -91,23 +83,86 @@ bin/connect-standalone.sh config/connect-standalone.properties config/connect-jd
 
 ## Publishing messages
 
-If no topics exist, one can be created using the following command:
+Messages can be published via the console producer script:
 
 ```shell
-bin/kafka-topics.sh --create --topic example-topic --bootstrap-server localhost:9092
+bin/kafka-console-producer.sh --topic example-topic --bootstrap-server localhost:9092
 ```
 
-At this point, a message can be published:
-
-```shell
-bin/windows/kafka-console-producer.sh --topic example-topic --bootstrap-server localhost:9092
-```
-
-Paste this message (as one line) to create a table. The table name will be the
-topic used in the kafka-console-producer topic
+A `>` greater-than symbol indicates that a messages can be published to the
+example topic from the interactive session. Paste the following minified JSON as
+a single line to publish messages and create the table `example-topic` in the
+QuestDB instance:
 
 <!-- prettier-ignore-start -->
 ```json
-{    "schema": {        "type": "struct",        "fields": [            {                "type": "boolean",                "optional": false,               "field": "flag"            },            {                "type": "int8",                "optional": false,                "field": "id8"           },           {                "type": "int16",                "optional": false,                "field": "id16"            },            {                "type":"int32",                "optional": false,                "field": "id32"            },          {                  "type": "int64",               "optional": false,                "field": "id64"            },            {                "type": "float",                "optional": false,                "field": "idFloat"            },            {                "type": "double",                "optional": false,                "field": "idDouble"            },              {                "type": "string",                "optional": true,                "field": "msg"            }      ],        "optional": false,        "name": "msgschema"    },    "payload": {        "flag": false,        "id8": 222,        "id16": 222,        "id32": 222,        "id64": 222,        "idFloat": 222.0,        "idDouble": 333.0,               "msg": "hi"  }}
+{"schema":{"type":"struct","fields":[{"type":"boolean","optional":false,"field":"flag"},{"type":"int8","optional":false,"field":"id8"},{"type":"int16","optional":false,"field":"id16"},{"type":"int32","optional":false,"field":"id32"},{"type":"int64","optional":false,"field":"id64"},{"type":"float","optional":false,"field":"idFloat"},{"type":"double","optional":false,"field":"idDouble"},{"type":"string","optional":true,"field":"msg"}],"optional":false,"name":"msgschema"},"payload":{"flag":false,"id8":222,"id16":222,"id32":222,"id64":222,"idFloat":222,"idDouble":333,"msg":"hi"}}
 ```
 <!-- prettier-ignore-end -->
+
+## JSON format
+
+The JSON object sent in the example above has the following structure containing
+`schema` and `payload` objects:
+
+```json
+{
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "type": "boolean",
+        "optional": false,
+        "field": "flag"
+      },
+      {
+        "type": "int8",
+        "optional": false,
+        "field": "id8"
+      },
+      {
+        "type": "int16",
+        "optional": false,
+        "field": "id16"
+      },
+      {
+        "type": "int32",
+        "optional": false,
+        "field": "id32"
+      },
+      {
+        "type": "int64",
+        "optional": false,
+        "field": "id64"
+      },
+      {
+        "type": "float",
+        "optional": false,
+        "field": "idFloat"
+      },
+      {
+        "type": "double",
+        "optional": false,
+        "field": "idDouble"
+      },
+      {
+        "type": "string",
+        "optional": true,
+        "field": "msg"
+      }
+    ],
+    "optional": false,
+    "name": "msgschema"
+  },
+  "payload": {
+    "flag": false,
+    "id8": 222,
+    "id16": 222,
+    "id32": 222,
+    "id64": 222,
+    "idFloat": 222,
+    "idDouble": 333,
+    "msg": "hi"
+  }
+}
+```

--- a/docs/third-party-tools/kafka.md
+++ b/docs/third-party-tools/kafka.md
@@ -46,7 +46,7 @@ Postgres server is running on the default port `8812`.
 
 Create a file `config/connect-jdbc.properties` with the following contents:
 
-```
+```shell
 name=local-jdbc-sink
 connector.class=io.confluent.connect.jdbc.JdbcSinkConnector
 connection.url=jdbc:postgresql://127.0.0.1:8812/qdb?useSSL=false

--- a/sidebars.js
+++ b/sidebars.js
@@ -65,6 +65,13 @@ module.exports = {
       ],
     },
     {
+      label: "Third-Party Tools",
+      type: "category",
+      items: [
+        "third-party-tools/kafka"
+      ],
+    },
+    {
       label: "Operations",
       type: "category",
       items: [

--- a/sidebars.js
+++ b/sidebars.js
@@ -65,7 +65,7 @@ module.exports = {
       ],
     },
     {
-      label: "Third-Party Tools",
+      label: "Third-party Tools",
       type: "category",
       items: [
         "third-party-tools/kafka"


### PR DESCRIPTION
__Changes:__
* Removed Postgres config section
* Clean up one-liner example for publishing JSON messages with pretty example to demonstrate the schema
* Add better instructions for making `.jar` files available to Kafka