### PR TITLE
fix: update docusaurus to latest - dedup "twitter:image" metas

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "serve": "docusaurus serve"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-alpha.69",
-    "@docusaurus/module-type-aliases": "2.0.0-alpha.69",
-    "@docusaurus/plugin-pwa": "2.0.0-alpha.69",
-    "@docusaurus/preset-classic": "2.0.0-alpha.69",
+    "@docusaurus/core": "2.0.0-alpha.b11c24b75",
+    "@docusaurus/module-type-aliases": "2.0.0-alpha.b11c24b75",
+    "@docusaurus/plugin-pwa": "2.0.0-alpha.b11c24b75",
+    "@docusaurus/preset-classic": "2.0.0-alpha.b11c24b75",
     "@questdb/sql-grammar": "1.0.5",
     "@tsconfig/docusaurus": "1.0.2",
     "@types/react": "16.9.56",
@@ -67,11 +67,7 @@
     "webpack-manifest-plugin": "2.2.0"
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
+    "production": [">0.2%", "not dead", "not op_mini all"],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,25 @@
 # yarn lockfile v1
 
 
+"@algolia/autocomplete-core@^1.0.0-alpha.35":
+  version "1.0.0-alpha.37"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.0.0-alpha.37.tgz#d41a6561b38761c4967ff7aa3e1d5d0aa3ceb31c"
+  integrity sha512-sgyhudj7GphoVpB91i01SYKQGuqe4ByYf+yzKXUBS2Vswhtzv25emOA8RB+rr51ogeKlzpGKopZgglQnVw/CYg==
+  dependencies:
+    "@algolia/autocomplete-shared" "1.0.0-alpha.37"
+
+"@algolia/autocomplete-preset-algolia@^1.0.0-alpha.35":
+  version "1.0.0-alpha.37"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.37.tgz#8c8e8ccec13bdea6db72c9994329c63fe804ca58"
+  integrity sha512-983tVpmzU9zNbS135ZyEXqG3Rd2ECkfMYNvPjE7ltRG7QjhIKdG/jCzM+W+9mOPtasK5oQbJVh3IxaGOALYZ+Q==
+  dependencies:
+    "@algolia/autocomplete-shared" "1.0.0-alpha.37"
+
+"@algolia/autocomplete-shared@1.0.0-alpha.37":
+  version "1.0.0-alpha.37"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.0.0-alpha.37.tgz#07d8fc2bd983df195e39716c9b432fd9ec85533a"
+  integrity sha512-5FSPDoq+AFwgdFnUv5BksvE7apbpo6cQ0hozNQscjcCaNceH47HzBLE6FGXzQWtXHnYRaOLYKXMHbg8KpnADMA==
+
 "@algolia/cache-browser-local-storage@4.8.0":
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.8.0.tgz#42137b8e18474e8a94bd7206d7e4ada2daf5da04"
@@ -1112,27 +1131,28 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@docsearch/css@^1.0.0-alpha.28":
-  version "1.0.0-alpha.28"
-  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-1.0.0-alpha.28.tgz#c8a2cd8c1bb3a6855c51892e9dbdab5d42fe6e23"
-  integrity sha512-1AhRzVdAkrWwhaxTX6/R7SnFHz8yLz1W8I/AldlTrfbNvZs9INk1FZiEFTJdgHaP68nhgQNWSGlQiDiI3y2RYg==
+"@docsearch/css@3.0.0-alpha.32":
+  version "3.0.0-alpha.32"
+  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.0.0-alpha.32.tgz#3d89c8db4035531d201f74ef2115f72094a24036"
+  integrity sha512-wafLX/jT1NPAwifPhzMJX394PjKdqf5TA4cz/JgvBYR1/+MiErLk/pyCmocXkawWGR17/6u2qw3wYvXu/Qe/DQ==
 
-"@docsearch/react@^1.0.0-alpha.27":
-  version "1.0.0-alpha.28"
-  resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-1.0.0-alpha.28.tgz#4f039ed79f8b3332b19a57677b219aebc5010e9d"
-  integrity sha512-XjJOnCBXn+UZmtuDmgzlVIHnnvh6yHVwG4aFq8AXN6xJEIX3f180FvGaowFWAxgdtHplJxFGux0Xx4piHqBzIw==
+"@docsearch/react@^3.0.0-alpha.31":
+  version "3.0.0-alpha.32"
+  resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-3.0.0-alpha.32.tgz#ae3fa82e9c88683d9415bc439c4af7e2c0cfa5b7"
+  integrity sha512-2jqzPJu4y0mWiwwm+Kfgf/97Q8XaGxj1+jJfGJpJLkJyD8S2tK4OikyIRWI9gI9k3m48HxFm0+P8uAYYtIyjqA==
   dependencies:
-    "@docsearch/css" "^1.0.0-alpha.28"
-    "@francoischalifour/autocomplete-core" "^1.0.0-alpha.28"
-    "@francoischalifour/autocomplete-preset-algolia" "^1.0.0-alpha.28"
+    "@algolia/autocomplete-core" "^1.0.0-alpha.35"
+    "@algolia/autocomplete-preset-algolia" "^1.0.0-alpha.35"
+    "@docsearch/css" "3.0.0-alpha.32"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.0-alpha.69.tgz#1452b9b2f2c5f67f75a45275e7eb5943c1f43a24"
-  integrity sha512-dJGbZ91QH9I5Nrhm0W6ZHe4j8Qv0RBclQkx3WayExxFSHgQUlBM0hBReJxAbTKc1uSJgG7OPpEWnzbZjyK9t/Q==
+"@docusaurus/core@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.0-alpha.b11c24b75.tgz#7c4e06b41bf14980aabaeb71953821ec1c2aa046"
+  integrity sha512-6rlY2YQS8sPxIw7VLNXMUANvJtZX1CzHdUO8U5vhN25Q4S7ISMb7nSlzdpymxaUZ/V0HCvdnixfVnluqyQfd8g==
   dependencies:
     "@babel/core" "^7.12.3"
+    "@babel/generator" "^7.12.5"
     "@babel/plugin-proposal-nullish-coalescing-operator" "^7.12.1"
     "@babel/plugin-proposal-optional-chaining" "^7.12.1"
     "@babel/plugin-syntax-dynamic-import" "^7.8.3"
@@ -1142,10 +1162,11 @@
     "@babel/preset-typescript" "^7.12.1"
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.5"
-    "@docusaurus/cssnano-preset" "2.0.0-alpha.69"
-    "@docusaurus/types" "2.0.0-alpha.69"
-    "@docusaurus/utils" "2.0.0-alpha.69"
-    "@docusaurus/utils-validation" "2.0.0-alpha.69"
+    "@babel/traverse" "^7.12.5"
+    "@docusaurus/cssnano-preset" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/types" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils-validation" "2.0.0-alpha.b11c24b75"
     "@endiliey/static-site-generator-webpack-plugin" "^4.0.0"
     "@svgr/webpack" "^5.4.0"
     babel-loader "^8.2.1"
@@ -1208,25 +1229,25 @@
     webpack-merge "^4.2.2"
     webpackbar "^4.0.0"
 
-"@docusaurus/cssnano-preset@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-alpha.69.tgz#19bc826850c9107c7bae507589284ac6f66b8485"
-  integrity sha512-Gv75LL4e2XnApNMPQ1mYVotH+0RKsg3WewPh7zSfEJvyzD6F+SHxIcu+tNSwkRMexlCLy6BHgOyEwvhom+VoaA==
+"@docusaurus/cssnano-preset@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-alpha.b11c24b75.tgz#1611420026bf41ce3696bc114a48c24823d11215"
+  integrity sha512-4mapiFvPT/3bBwHPVaF2wYjl9CeP8vJ0lcQWo2ny6R7VrB0zy6yN+RZBvCZBC8FFbT6rlZlTO/R/b75Bleymdw==
   dependencies:
     cssnano-preset-advanced "^4.0.7"
     postcss "^7.0.2"
     postcss-combine-duplicated-selectors "^9.1.0"
     postcss-sort-media-queries "^1.7.26"
 
-"@docusaurus/mdx-loader@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-alpha.69.tgz#cf882670d2cb05902197776bba471d04696ceae9"
-  integrity sha512-yieXX7RhzLasN1bBj/tMj43l+DRu3VEyFRC63khYwfAZyhKtlMEL9eEaKMN3eqvnZD2u6G+nxXafwpqLdqNAWg==
+"@docusaurus/mdx-loader@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-alpha.b11c24b75.tgz#fc5861a178e91a491e9c756e07accfb58a47a173"
+  integrity sha512-j5+oAuVFct4WAVzt4tgqPUvXto7fL/AKcfzSu+JSTQ66ZjquYkfv+VqSRQntq7yGKmfuVghuT+hv2fEzHhsqaQ==
   dependencies:
     "@babel/parser" "^7.12.5"
     "@babel/traverse" "^7.12.5"
-    "@docusaurus/core" "2.0.0-alpha.69"
-    "@docusaurus/utils" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils" "2.0.0-alpha.b11c24b75"
     "@mdx-js/mdx" "^1.6.21"
     "@mdx-js/react" "^1.6.21"
     escape-html "^1.0.3"
@@ -1242,21 +1263,21 @@
     url-loader "^4.1.1"
     webpack "^4.44.1"
 
-"@docusaurus/module-type-aliases@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-alpha.69.tgz#eb46ee531cab6e1ac8e9c148c4cffc8151f36751"
-  integrity sha512-4aYZ0KrydLe2t5Ae4LWF2QHhEu4mDJOwwpEf3kEsmZU+OBrWoMlN3W4QGPIt9rJmxrRk5pniz3o+XATSFXZNNQ==
+"@docusaurus/module-type-aliases@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-alpha.b11c24b75.tgz#a9297a880b3e9a14a30dd08c5784e86a76de0a6d"
+  integrity sha512-gaN95unydiuXTmhjf8BgNYSCUykCQXn63vhmZKIcHeoJiCijSyj4PI/t65DyvrAaDnjtnQVABxTq5DVbRA4iCw==
 
-"@docusaurus/plugin-content-blog@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-alpha.69.tgz#ba96b65c1d19452487330c860677ee20a5af5275"
-  integrity sha512-zN3c8ZiYpOid5f6YbxGZhVN8E5a4HmkyVJWTXts5tE0pdeiTuk0cfB5Iko4rnIDTztz7pJJCToIzKu07DcImww==
+"@docusaurus/plugin-content-blog@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-alpha.b11c24b75.tgz#6b026142e2a7b84323891fc6687b9b94cea4741a"
+  integrity sha512-flDphIowgkNkiNUlZl4xC+zvyrj7EjqQ558Y9GQd1UUUK0DaiBS3w2KdLQ5bxUi4M9UwHgW4BPwcqyrVsiwu2A==
   dependencies:
-    "@docusaurus/core" "2.0.0-alpha.69"
-    "@docusaurus/mdx-loader" "2.0.0-alpha.69"
-    "@docusaurus/types" "2.0.0-alpha.69"
-    "@docusaurus/utils" "2.0.0-alpha.69"
-    "@docusaurus/utils-validation" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/mdx-loader" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/types" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils-validation" "2.0.0-alpha.b11c24b75"
     chalk "^3.0.0"
     feed "^4.2.1"
     fs-extra "^9.0.1"
@@ -1268,16 +1289,16 @@
     remark-admonitions "^1.2.1"
     webpack "^4.44.1"
 
-"@docusaurus/plugin-content-docs@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-alpha.69.tgz#5ef4d293765d02e11ffb2a201c491a34f92e2a83"
-  integrity sha512-u+2juUJWFd/v/x8NU4UzQf6k5tc21oZj6s/IFQDTse/5QeHkMrkw0aqUeHbGWet4foBRnx+021vmrPPqxeV/dQ==
+"@docusaurus/plugin-content-docs@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-alpha.b11c24b75.tgz#2f4948a8c381fa92478406a333bbc20470648df5"
+  integrity sha512-fA6oUQIShqqGLSTRLtRegH3CpY4G0JLwykdYBCyOYJdLmX+0dLquvHyW540SZFtzNZ1KPyYxfSaSOQd2cK0I7A==
   dependencies:
-    "@docusaurus/core" "2.0.0-alpha.69"
-    "@docusaurus/mdx-loader" "2.0.0-alpha.69"
-    "@docusaurus/types" "2.0.0-alpha.69"
-    "@docusaurus/utils" "2.0.0-alpha.69"
-    "@docusaurus/utils-validation" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/mdx-loader" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/types" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils-validation" "2.0.0-alpha.b11c24b75"
     chalk "^3.0.0"
     execa "^3.4.0"
     fs-extra "^9.0.1"
@@ -1296,57 +1317,58 @@
     utility-types "^3.10.0"
     webpack "^4.44.1"
 
-"@docusaurus/plugin-content-pages@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-alpha.69.tgz#215c52c7788b3794dc692ceb3d0a563adddc0435"
-  integrity sha512-RmEuhKFGagLyH42ggTweWHjaf82qbD9Xp7rXx10iHAUW2bJsMyGioag6gAw0Q+DeMMeHtMJdPsU99cuYqUdTpw==
+"@docusaurus/plugin-content-pages@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-alpha.b11c24b75.tgz#b9ab22911302e50eb605d95f5e633f66e3691d15"
+  integrity sha512-JrT4N8UHVpFAjQcV+6cbUkB038eHBnoOveLkqgDF24AByA60oEvm0Z9VIgUTQkLMJynaJlgQe9Br4R0bPOcIwA==
   dependencies:
-    "@docusaurus/core" "2.0.0-alpha.69"
-    "@docusaurus/mdx-loader" "2.0.0-alpha.69"
-    "@docusaurus/types" "2.0.0-alpha.69"
-    "@docusaurus/utils" "2.0.0-alpha.69"
-    "@docusaurus/utils-validation" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/mdx-loader" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/types" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils-validation" "2.0.0-alpha.b11c24b75"
     globby "^10.0.1"
     joi "^17.2.1"
     loader-utils "^1.2.3"
+    lodash "^4.17.19"
     minimatch "^3.0.4"
     remark-admonitions "^1.2.1"
     slash "^3.0.0"
     webpack "^4.44.1"
 
-"@docusaurus/plugin-debug@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-alpha.69.tgz#643c3119d688ffa318eeb7d719942e1e24ad5a95"
-  integrity sha512-wvLBvntbuh25RCkKEeuwLl2h9OzMXZLIQWNa6FvAtmc8Xaomn3JkYnWn/fAKiBiOExN1ZEf9XomKVLNIUJ9xOg==
+"@docusaurus/plugin-debug@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-alpha.b11c24b75.tgz#fb4e4fcd38da795fc0fcee64b52b4153781fc475"
+  integrity sha512-xg/3ejADNGgkn0+GU+pHmJmVA5QTIkNcEuU6ZVZnYZHwrQAWmT5AbEvrICZild7CFv/xR/6FHe8PDvzVaVCwHw==
   dependencies:
-    "@docusaurus/core" "2.0.0-alpha.69"
-    "@docusaurus/types" "2.0.0-alpha.69"
-    "@docusaurus/utils" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/types" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils" "2.0.0-alpha.b11c24b75"
     react-json-view "^1.19.1"
 
-"@docusaurus/plugin-google-analytics@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-alpha.69.tgz#031e0e4431842b1c9ba99fb6dd6dd258ee91f05e"
-  integrity sha512-CrGy8DeJqMZdNmbLNyfgLtjMcapOoqY8jbJiKYCELI8SZ8Ns28i8Yh5W9qe4KxGqSQXvVWHg36xJVG/xAF/6jA==
+"@docusaurus/plugin-google-analytics@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-alpha.b11c24b75.tgz#27ad9eef0453892a5d5a7e2f6207db66aef0e166"
+  integrity sha512-qQEkBRwOSph+p95EM+UOIMjLi/INUbQihvoqTC5kzpKZrR71kSX96gm21ax2fY16z+R2y4QiTMVSi3WT4DUc5Q==
   dependencies:
-    "@docusaurus/core" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
 
-"@docusaurus/plugin-google-gtag@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-alpha.69.tgz#b6d9c77e99f60dbffe2622f0567fce589bc420b3"
-  integrity sha512-mDAKBRkB3UJMuAUPqC43mNr8PPu3QuUbCLisJIvg7VMp9XoAcOImNZWmY2Smd+Law2tJkW3cBFPvm3fcVvJ1vA==
+"@docusaurus/plugin-google-gtag@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-alpha.b11c24b75.tgz#c962600ae1f2711b7d55e08041fe86e157ff1cba"
+  integrity sha512-uO/kTGcrICMLOUpr7Yw+xMPZPK+VSeJ8naQUOgocl9xYCgtGXAYyxojAjUpO7BYjVeiJT2aglklms+3C03hPtQ==
   dependencies:
-    "@docusaurus/core" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
 
-"@docusaurus/plugin-pwa@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-pwa/-/plugin-pwa-2.0.0-alpha.69.tgz#864f6f6250992d21d6e6742d546e8c1323b061a7"
-  integrity sha512-qTrgHFTjM5Ra5vYvDnzUpUJ79U4mAJSC+nf7mO+Y2wvUk0FqitQ+JS/j/ruFucbC5LMTLZVojArY2TX6h7QSFQ==
+"@docusaurus/plugin-pwa@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-pwa/-/plugin-pwa-2.0.0-alpha.b11c24b75.tgz#cae53a41a7abf8b5aa397b7b50076bd32cc0024c"
+  integrity sha512-Go2/U44RcIWnkrece9Gx+Sa2ah9wVjXtM+vGf6hU500L7evhe/TFcxFd1jhHXZCWhgmnlMuw6jATY5bNxgh4tQ==
   dependencies:
     "@babel/plugin-proposal-nullish-coalescing-operator" "^7.12.1"
     "@babel/plugin-proposal-optional-chaining" "^7.12.1"
     "@babel/preset-env" "^7.12.1"
-    "@docusaurus/core" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
     babel-loader "^8.2.1"
     clsx "^1.1.1"
     core-js "^2.6.5"
@@ -1358,45 +1380,46 @@
     workbox-precaching "^5.1.4"
     workbox-window "^5.1.4"
 
-"@docusaurus/plugin-sitemap@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-alpha.69.tgz#ffda02b4be468b3dfeed8fde3c2f2971ee839078"
-  integrity sha512-DqrXm1PiWWNN5wbY1iVg0sdkCL3KZEj7uyjmZfXIfMQaEF2ErqJDY07QAwANrl27huPQmmc9tYwW3FqgKbVlbA==
+"@docusaurus/plugin-sitemap@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-alpha.b11c24b75.tgz#45371026fb11be8fc404d23e759677b7d4fc1a86"
+  integrity sha512-NIe1y3c9U7sgX946+x8fo7sLQw6PrbFfa7AGzPdrbntSpBhBc4VFNH/qHYSUf2Kj1s0Umm1wPWyMN6n3XBX4Qw==
   dependencies:
-    "@docusaurus/core" "2.0.0-alpha.69"
-    "@docusaurus/types" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/types" "2.0.0-alpha.b11c24b75"
     fs-extra "^9.0.1"
     joi "^17.2.1"
     sitemap "^3.2.2"
 
-"@docusaurus/preset-classic@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.0.0-alpha.69.tgz#f8ecfd610852e6754037f006edc38dc4d6146da6"
-  integrity sha512-4RiLXB+1vYzgTxGRnZqrYU/7gSsqUWYbofy7Ce5i4NF+L65B0mnBGaBhU0j1ZQJUMuozByRbf54wExZB25Re0A==
+"@docusaurus/preset-classic@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.0.0-alpha.b11c24b75.tgz#bb417eef2e6a8fcc0e9d56eaa2b9844da78bbdbb"
+  integrity sha512-yltgTMI3LhbnPw5hayUjVU7OuZHgRl/KMNIFv7XZtvWYoNKzd9q2WnxjCkBzCwlAXAT16cXRwfKzub5L6cQKVw==
   dependencies:
-    "@docusaurus/core" "2.0.0-alpha.69"
-    "@docusaurus/plugin-content-blog" "2.0.0-alpha.69"
-    "@docusaurus/plugin-content-docs" "2.0.0-alpha.69"
-    "@docusaurus/plugin-content-pages" "2.0.0-alpha.69"
-    "@docusaurus/plugin-debug" "2.0.0-alpha.69"
-    "@docusaurus/plugin-google-analytics" "2.0.0-alpha.69"
-    "@docusaurus/plugin-google-gtag" "2.0.0-alpha.69"
-    "@docusaurus/plugin-sitemap" "2.0.0-alpha.69"
-    "@docusaurus/theme-classic" "2.0.0-alpha.69"
-    "@docusaurus/theme-search-algolia" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-content-blog" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-content-docs" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-content-pages" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-debug" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-google-analytics" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-google-gtag" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-sitemap" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/theme-classic" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/theme-search-algolia" "2.0.0-alpha.b11c24b75"
 
-"@docusaurus/theme-classic@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.0.0-alpha.69.tgz#64885b973df695e52356e3484fd9a03101b86e58"
-  integrity sha512-BterTyQvGrHS4oC/USXDG6GHt90oWUFyDg7oQ8WAa2zfkZTgcM3LiZeUYbn8vwy/HVU7hOWCixPTtY3R9iNZ9Q==
+"@docusaurus/theme-classic@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.0.0-alpha.b11c24b75.tgz#01da33a8e2ac0bbe75d4831edb790acf0f55e42b"
+  integrity sha512-IGKowPh8g4nGcGiMVM7ktmyZkIQ61/UCB4Iv3osCCV9i8DR7dm/j1FwXFuA7xXlJGTp35WJaGYj/8ysrTHvquw==
   dependencies:
-    "@docusaurus/core" "2.0.0-alpha.69"
-    "@docusaurus/plugin-content-blog" "2.0.0-alpha.69"
-    "@docusaurus/plugin-content-docs" "2.0.0-alpha.69"
-    "@docusaurus/plugin-content-pages" "2.0.0-alpha.69"
-    "@docusaurus/theme-common" "2.0.0-alpha.69"
-    "@docusaurus/types" "2.0.0-alpha.69"
-    "@docusaurus/utils-validation" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-content-blog" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-content-docs" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-content-pages" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/theme-common" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/types" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils-validation" "2.0.0-alpha.b11c24b75"
     "@mdx-js/mdx" "^1.6.21"
     "@mdx-js/react" "^1.6.21"
     "@types/react-toggle" "^4.0.2"
@@ -1412,25 +1435,26 @@
     react-router-dom "^5.2.0"
     react-toggle "^4.1.1"
 
-"@docusaurus/theme-common@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.0.0-alpha.69.tgz#4fd13db9fdd2b94e2010cd579ccfacde41824839"
-  integrity sha512-6Pq+gmmYOey86z0HaOOyIWMg+ftcl8KR0bamNQD3wkBtiEy7ymcHMlck887W+fFxttWLPo4+/HzfYFUqSoCHkQ==
+"@docusaurus/theme-common@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.0.0-alpha.b11c24b75.tgz#d435d7ff5afd74fe2fe47d8b9bd0cabdbf7205fb"
+  integrity sha512-JS1M6Ui37u9Fz/H4Diqyo4IR3DumbwTBlmXYKWCxMkBqrgDhmqf0wWoUFb/w9YvXGNj97OouyxI6DsWoIAqZGQ==
   dependencies:
-    "@docusaurus/core" "2.0.0-alpha.69"
-    "@docusaurus/plugin-content-blog" "2.0.0-alpha.69"
-    "@docusaurus/plugin-content-docs" "2.0.0-alpha.69"
-    "@docusaurus/plugin-content-pages" "2.0.0-alpha.69"
-    "@docusaurus/types" "2.0.0-alpha.69"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-content-blog" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-content-docs" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/plugin-content-pages" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/types" "2.0.0-alpha.b11c24b75"
 
-"@docusaurus/theme-search-algolia@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-alpha.69.tgz#955da97fd3052118fee1b5ffa1abfa33043fd67a"
-  integrity sha512-hPg54EwZudgqjs7D6QbWMbG3XmI10XtcqED9VMg6R3LPBG3317UhtuEGa1jJrF6hDN/HHbzWZOQ00LLBHpf9+Q==
+"@docusaurus/theme-search-algolia@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-alpha.b11c24b75.tgz#2eccad51fc222ba20573f6c864590b805c64e6b3"
+  integrity sha512-+8jJneRBPrUfrmnxoPfdhZluB6yH8uyAau1IZLnRHkuAvRy2gxldOjnwBoxFqCVul1rWDxvHqtHKWeiwXvHZSg==
   dependencies:
-    "@docsearch/react" "^1.0.0-alpha.27"
-    "@docusaurus/core" "2.0.0-alpha.69"
-    "@docusaurus/utils" "2.0.0-alpha.69"
+    "@docsearch/react" "^3.0.0-alpha.31"
+    "@docusaurus/core" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/theme-common" "2.0.0-alpha.b11c24b75"
+    "@docusaurus/utils" "2.0.0-alpha.b11c24b75"
     algoliasearch "^4.0.0"
     algoliasearch-helper "^3.1.1"
     clsx "^1.1.1"
@@ -1438,35 +1462,36 @@
     joi "^17.2.1"
     lodash "^4.17.19"
 
-"@docusaurus/types@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.0.0-alpha.69.tgz#05d1a28f325600185b3cb4088326c865fb4b54a9"
-  integrity sha512-8TgHmUMH5q+5D93nyugk/dtUeGPblRE++gxxrwjNYnJucRUNDKRC8kJhEozODGcSfXddTeMalPvbRKSz9Pxj2g==
+"@docusaurus/types@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.0.0-alpha.b11c24b75.tgz#1bec62847db5567a783e5f300a34fd2bac1a2fe4"
+  integrity sha512-GfUwx1DT47kJLtI/ZWHwykbpozyfmcBo1IyCsEdnSzDJB1AmIybZhZZdOUs2QuORoRcaLTstgCygETCcxjhodg==
   dependencies:
     "@types/webpack" "^4.41.0"
     commander "^4.0.1"
     querystring "0.2.0"
     webpack-merge "^4.2.2"
 
-"@docusaurus/utils-validation@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.0.0-alpha.69.tgz#35adab0f2b787dfdcf508ea0aa3552578be583a5"
-  integrity sha512-kjSZS8WOCVlqCLHOhbIDqztmSAPkBva51oT/oohs4WaNdvT6e0PdLycUA2Dg3pXLw1FXsiMxluCYyC8BGX0B+Q==
+"@docusaurus/utils-validation@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.0.0-alpha.b11c24b75.tgz#5790057fe96ff801674ef18bd287edd7f531992e"
+  integrity sha512-N89SXHYVYXoKHE/Q//BrGbFA6A0x/9UgyHeykF7fdAzAEI6wUPQzq6Wq+bZPJtAWfaRFBwNFA0ExQrG3U+rFwA==
   dependencies:
-    "@docusaurus/utils" "2.0.0-alpha.69"
+    "@docusaurus/utils" "2.0.0-alpha.b11c24b75"
     chalk "^3.0.0"
     joi "^17.2.1"
 
-"@docusaurus/utils@2.0.0-alpha.69":
-  version "2.0.0-alpha.69"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.0.0-alpha.69.tgz#9532cd489742beede570575ab70265dacecb3f24"
-  integrity sha512-RpxqcjPT0L+MxLyS/4QOHp/2hlKPcPoDyvfqtTJiS9DPtUzkH573a5/yMbfzz8IbPeYWRCPL2qxWtmN7XCZ/sQ==
+"@docusaurus/utils@2.0.0-alpha.b11c24b75":
+  version "2.0.0-alpha.b11c24b75"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.0.0-alpha.b11c24b75.tgz#f22ea174ba890616b16039996d9bf1553398bbbb"
+  integrity sha512-ItxhJ6rcEyyWvYW1WA2/z1Dhu/lxaJNVTU8lLikHo+v4TLdBw0GlgBOvTT8gWIVLBAmKdOcmMeweEyysWnhAXg==
   dependencies:
-    "@docusaurus/types" "2.0.0-alpha.69"
+    "@docusaurus/types" "2.0.0-alpha.b11c24b75"
     chalk "^3.0.0"
     escape-string-regexp "^2.0.0"
     fs-extra "^9.0.1"
     gray-matter "^4.0.2"
+    lodash "^4.17.20"
     lodash.camelcase "^4.3.0"
     lodash.kebabcase "^4.1.1"
     resolve-pathname "^3.0.0"
@@ -1497,16 +1522,6 @@
     lodash "^4.17.19"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
-
-"@francoischalifour/autocomplete-core@^1.0.0-alpha.28":
-  version "1.0.0-alpha.28"
-  resolved "https://registry.yarnpkg.com/@francoischalifour/autocomplete-core/-/autocomplete-core-1.0.0-alpha.28.tgz#6b9d8491288e77f831e9b345d461623b0d3f5005"
-  integrity sha512-rL9x+72btViw+9icfBKUJjZj87FgjFrD2esuTUqtj4RAX3s4AuVZiN8XEsfjQBSc6qJk31cxlvqZHC/BIyYXgg==
-
-"@francoischalifour/autocomplete-preset-algolia@^1.0.0-alpha.28":
-  version "1.0.0-alpha.28"
-  resolved "https://registry.yarnpkg.com/@francoischalifour/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.28.tgz#a5ad7996f42e43e4acbb4e0010d663746d0e9997"
-  integrity sha512-bprfNmYt1opFUFEtD2XfY/kEsm13bzHQgU80uMjhuK0DJ914IjolT1GytpkdM6tJ4MBvyiJPP+bTtWO+BZ7c7w==
 
 "@hapi/address@2.x.x":
   version "2.1.4"


### PR DESCRIPTION
Before this commit, Docusaurus was generating duplicated "twitter:image"
metas, this was caused by a typo in Docusaurus. The problem was fixed
upstream [1].

We now use Docusaurus with the canary version that contains the fix.

[1] https://github.com/facebook/docusaurus/pull/3900


----

#