### PR TITLE
docs: correct SAMPLE BY diagram with Timestamp, update .railroad EBNF

### DIFF
--- a/static/img/docs/diagrams/.railroad
+++ b/static/img/docs/diagrams/.railroad
@@ -44,7 +44,7 @@ Dynamic-timestamp
 
 
 sampleBy ::=
-someSelectStatement... 'SAMPLE' 'BY' n ( 's' | 'm' | 'h' | 'd' | 'M' | )
+someSelectStatement... 'SAMPLE' 'BY' n ( 'T' | 's' | 'm' | 'h' | 'd' | 'M' | )
 
 distinct
   ::= 'SELECT' 'DISTINCT' ( columnName (',' columnName)* ) 'FROM' tableName

--- a/static/img/docs/diagrams/sampleBy.svg
+++ b/static/img/docs/diagrams/sampleBy.svg
@@ -1,60 +1,72 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="523" height="245">
-    <defs>
-        <style type="text/css">
-            @namespace "http://www.w3.org/2000/svg";
-                .line                 {fill: none; stroke: #636273;}
-                .bold-line            {stroke: #636273; shape-rendering: crispEdges; stroke-width: 2; }
-                .thin-line            {stroke: #636273; shape-rendering: crispEdges}
-                .filled               {fill: #636273; stroke: none;}
-                text.terminal         {font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, Cantarell, Helvetica, sans-serif;
-                font-size: 12px;
-                fill: #ffffff;
-                font-weight: bold;
-                }
-                text.nonterminal      {font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, Cantarell, Helvetica, sans-serif;
-                font-size: 12px;
-                fill: #e289a4;
-                font-weight: normal;
-                }
-                text.regexp           {font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, Cantarell, Helvetica, sans-serif;
-                font-size: 12px;
-                fill: #00141F;
-                font-weight: normal;
-                }
-                rect, circle, polygon {fill: none; stroke: none;}
-                rect.terminal         {fill: none; stroke: #be2f5b;}
-                rect.nonterminal      {fill: rgba(255,255,255,0.1); stroke: none;}
-                rect.text             {fill: none; stroke: none;}
-                polygon.regexp        {fill: #C7ECFF; stroke: #038cbc;}
-        </style>
-    </defs>
-    <polygon points="9 17 1 13 1 21"/>
-    <polygon points="17 17 9 13 9 21"/><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#someSelectStatement..." xlink:title="someSelectStatement...">
+
+
+<svg xmlns="http://www.w3.org/2000/svg" width="523" height="289">
+  <defs>
+    <style type="text/css">
+      @namespace "http://www.w3.org/2000/svg";
+      .line                 {fill: none; stroke: #636273;}
+      .bold-line            {stroke: #636273; shape-rendering: crispEdges; stroke-width: 2; }
+      .thin-line            {stroke: #636273; shape-rendering: crispEdges}
+      .filled               {fill: #636273; stroke: none;}
+      text.terminal         {font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, Cantarell, Helvetica, sans-serif;
+      font-size: 12px;
+      fill: #ffffff;
+      font-weight: bold;
+      }
+      text.nonterminal      {font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, Cantarell, Helvetica, sans-serif;
+      font-size: 12px;
+      fill: #e289a4;
+      font-weight: normal;
+      }
+      text.regexp           {font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, Cantarell, Helvetica, sans-serif;
+      font-size: 12px;
+      fill: #00141F;
+      font-weight: normal;
+      }
+      rect, circle, polygon {fill: none; stroke: none;}
+      rect.terminal         {fill: none; stroke: #be2f5b;}
+      rect.nonterminal      {fill: rgba(255,255,255,0.1); stroke: none;}
+      rect.text             {fill: none; stroke: none;}
+      polygon.regexp        {fill: #C7ECFF; stroke: #038cbc;}
+    </style>
+  </defs>
+  <polygon points="9 17 1 13 1 21"/>
+  <polygon points="17 17 9 13 9 21"/>
+  <a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#someSelectStatement..." xlink:title="someSelectStatement...">
     <rect x="31" y="3" width="172" height="32"/>
     <rect x="29" y="1" width="172" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="39" y="21">someSelectStatement...</text></a><rect x="223" y="3" width="74" height="32" rx="10"/>
-    <rect x="221" y="1" width="74" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="231" y="21">SAMPLE</text>
-    <rect x="317" y="3" width="38" height="32" rx="10"/>
-    <rect x="315" y="1" width="38" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="325" y="21">BY</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#n" xlink:title="n">
+    <text class="nonterminal" x="39" y="21">someSelectStatement...</text>
+  </a>
+  <rect x="223" y="3" width="74" height="32" rx="10"/>
+  <rect x="221" y="1" width="74" height="32" class="terminal" rx="10"/>
+  <text class="terminal" x="231" y="21">SAMPLE</text>
+  <rect x="317" y="3" width="38" height="32" rx="10"/>
+  <rect x="315" y="1" width="38" height="32" class="terminal" rx="10"/>
+  <text class="terminal" x="325" y="21">BY</text>
+  <a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#n" xlink:title="n">
     <rect x="375" y="3" width="28" height="32"/>
     <rect x="373" y="1" width="28" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="383" y="21">n</text></a><rect x="443" y="35" width="26" height="32" rx="10"/>
-    <rect x="441" y="33" width="26" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="451" y="53">s</text>
-    <rect x="443" y="79" width="32" height="32" rx="10"/>
-    <rect x="441" y="77" width="32" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="451" y="97">m</text>
-    <rect x="443" y="123" width="28" height="32" rx="10"/>
-    <rect x="441" y="121" width="28" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="451" y="141">h</text>
-    <rect x="443" y="167" width="28" height="32" rx="10"/>
-    <rect x="441" y="165" width="28" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="451" y="185">d</text>
-    <rect x="443" y="211" width="30" height="32" rx="10"/>
-    <rect x="441" y="209" width="30" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="451" y="229">M</text>
-    <path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m172 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m28 0 h10 m20 0 h10 m0 0 h42 m-72 0 h20 m52 0 h20 m-92 0 q10 0 10 10 m72 0 q0 -10 10 -10 m-82 10 v12 m72 0 v-12 m-72 12 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m26 0 h10 m0 0 h6 m-62 -10 v20 m72 0 v-20 m-72 20 v24 m72 0 v-24 m-72 24 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m32 0 h10 m-62 -10 v20 m72 0 v-20 m-72 20 v24 m72 0 v-24 m-72 24 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m28 0 h10 m0 0 h4 m-62 -10 v20 m72 0 v-20 m-72 20 v24 m72 0 v-24 m-72 24 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m28 0 h10 m0 0 h4 m-62 -10 v20 m72 0 v-20 m-72 20 v24 m72 0 v-24 m-72 24 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m30 0 h10 m0 0 h2 m23 -208 h-3"/>
-    <polygon points="513 17 521 13 521 21"/>
-    <polygon points="513 17 505 13 505 21"/></svg>
+    <text class="nonterminal" x="383" y="21">n</text>
+  </a>
+  <rect x="443" y="35" width="28" height="32" rx="10"/>
+  <rect x="441" y="33" width="28" height="32" class="terminal" rx="10"/>
+  <text class="terminal" x="451" y="53">T</text>
+  <rect x="443" y="79" width="26" height="32" rx="10"/>
+  <rect x="441" y="77" width="26" height="32" class="terminal" rx="10"/>
+  <text class="terminal" x="451" y="97">s</text>
+  <rect x="443" y="123" width="32" height="32" rx="10"/>
+  <rect x="441" y="121" width="32" height="32" class="terminal" rx="10"/>
+  <text class="terminal" x="451" y="141">m</text>
+  <rect x="443" y="167" width="28" height="32" rx="10"/>
+  <rect x="441" y="165" width="28" height="32" class="terminal" rx="10"/>
+  <text class="terminal" x="451" y="185">h</text>
+  <rect x="443" y="211" width="28" height="32" rx="10"/>
+  <rect x="441" y="209" width="28" height="32" class="terminal" rx="10"/>
+  <text class="terminal" x="451" y="229">d</text>
+  <rect x="443" y="255" width="30" height="32" rx="10"/>
+  <rect x="441" y="253" width="30" height="32" class="terminal" rx="10"/>
+  <text class="terminal" x="451" y="273">M</text>
+  <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m172 0 h10 m0 0 h10 m74 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m28 0 h10 m20 0 h10 m0 0 h42 m-72 0 h20 m52 0 h20 m-92 0 q10 0 10 10 m72 0 q0 -10 10 -10 m-82 10 v12 m72 0 v-12 m-72 12 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m28 0 h10 m0 0 h4 m-62 -10 v20 m72 0 v-20 m-72 20 v24 m72 0 v-24 m-72 24 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m26 0 h10 m0 0 h6 m-62 -10 v20 m72 0 v-20 m-72 20 v24 m72 0 v-24 m-72 24 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m32 0 h10 m-62 -10 v20 m72 0 v-20 m-72 20 v24 m72 0 v-24 m-72 24 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m28 0 h10 m0 0 h4 m-62 -10 v20 m72 0 v-20 m-72 20 v24 m72 0 v-24 m-72 24 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m28 0 h10 m0 0 h4 m-62 -10 v20 m72 0 v-20 m-72 20 v24 m72 0 v-24 m-72 24 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m30 0 h10 m0 0 h2 m23 -252 h-3"/>
+  <polygon points="513 17 521 13 521 21"/>
+  <polygon points="513 17 505 13 505 21"/>
+</svg>


### PR DESCRIPTION
__Description:__
The `SAMPLE BY` diagram is missing a `T` property denoting Timestamp.
* `.railroad` EBNF file has been corrected
* updated the generated SVG to reflect the correction