### PR TITLE
chore: fix redirect with absolute URL to Grafana page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,4 @@
 /getstarted               /get-questdb
 /get-started              /get-questdb
-/reference/client/grafana /third-party-tools/grafana
+/docs/reference/client/grafana /docs/third-party-tools/grafana
 /blog/2020/12/10/building-a-garbage-free-network-stack-for-kafka-streams /blog/2020/12/10/non-blocking-io-without-garbage-collection


### PR DESCRIPTION
__Description:__
Redirects do not work by pattern matching path segments and must be absolute URLs