### PR TITLE
docs: fix broken front matter in Kafka post

### DIFF
--- a/blog/2020-12-10-garbage-free-stack-for-kafka-streams.md
+++ b/blog/2020-12-10-garbage-free-stack-for-kafka-streams.md
@@ -1,8 +1,5 @@
 ---
 title: Building a garbage-free network stack for Kafka streams
-
-
-streams
 author: Vlad Ilyushchenko
 author_title: QuestDB Team
 author_url: https://github.com/bluestreak01


### PR DESCRIPTION
__Description:__
Could not run `yarn start` due to broken keys in front matter