### PR TITLE
docs: update redirects after blog post rename

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,5 @@
 /getstarted               /get-questdb
 /get-started              /get-questdb
 /docs/reference/client/grafana /docs/third-party-tools/grafana
-/blog/2020/12/10/building-a-garbage-free-network-stack-for-kafka-streams /blog/2020/12/10/non-blocking-io-without-garbage-collection
+/blog/2020/12/10/building-a-garbage-free-network-stack-for-kafka-streams /blog/2020/12/10/garbage-free-stack-for-kafka-streams
+/blog/2020/12/10/non-blocking-io-without-garbage-collection /blog/2020/12/10/garbage-free-stack-for-kafka-streams


### PR DESCRIPTION
__Fixes:__
* Redirect needs to be updated for the new URL following the file rename in https://github.com/questdb/questdb.io/pull/296 