### PR TITLE
fix: correct typo so a tutorial post contains an h1 title

### DIFF
--- a/src/theme/TutorialPostItem/index.tsx
+++ b/src/theme/TutorialPostItem/index.tsx
@@ -80,7 +80,7 @@ function TutorialPostItem({
       ) : (
         <article className="margin-bottom--xl">
           <header>
-            <h2 className="margin-bottom--sm">{title}</h2>
+            <h1 className="margin-bottom--sm">{title}</h1>
           </header>
 
           <section className="markdown">


### PR DESCRIPTION
Minor change, "bump" the title on tutorial page from h2 to h1.