### PR TITLE
fix: update redirect path format for tutorials

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -5,7 +5,7 @@
 /blog/2020/12/10/non-blocking-io-without-garbage-collection /blog/2020/12/10/garbage-free-stack-for-kafka-streams
 /blog/2020/12/10/building-a-garbage-free-network-stack-for-kafka-streams /blog/2020/12/10/non-blocking-io-without-garbage-collection
 /blog/2020/10/19/grafana-tutorial /tutorial/2020/10/19/grafana
-/blog/2020-06-05-iot-on-questdb /tutorial/2020-06-05-iot-on-questdb
-/blog/2020-06-15-python-questdb-tutorial /tutorial/2020-06-15-python-questdb-tutorial
-/blog/2020-07-22-influxdb-lp-on-tcp /tutorial/2020-07-22-influxdb-lp-on-tcp
-/blog/2020-08-25-questitto /tutorial/2020-08-25-questitto
+/blog/2020-06-05-iot-on-questdb /tutorial/2020/06/05/iot-on-questdb
+/blog/2020-06-15-python-questdb-tutorial /tutorial/2020/06/15/python-questdb-tutorial
+/blog/2020-07-22-influxdb-lp-on-tcp /tutorial/2020/07/22/influxdb-lp-on-tcp
+/blog/2020-08-25-questitto /tutorial/2020/08/25/questitto


### PR DESCRIPTION
__Fixes:__
* Blog posts have the path segments in the format `YYYY-MM-DD-<title>` and tutorials should use `YYYY/MM/DD/<title>`