### PR TITLE
docs: update SAMPLE BY to reference FILL(fillOptions)

### DIFF
--- a/docs/reference/sql/fill.md
+++ b/docs/reference/sql/fill.md
@@ -4,8 +4,8 @@ sidebar_label: FILL
 description: FILL SQL keyword reference documentation.
 ---
 
-Specifies fill behavior for missing data for as part of a
-[SAMPLE BY](/docs/reference/sql/sample-by/) aggregation query.
+Specifies fill behavior for missing data as part of a
+[SAMPLE BY](/docs/reference/sql/sample-by/) aggregation queries.
 
 ## Syntax
 
@@ -13,19 +13,20 @@ Specifies fill behavior for missing data for as part of a
 
 ### Options
 
-There are as many `fillOption` as there are `aggregate` columns in your query.
+The `FILL` keyword expects a `fillOption` for each aggregate column. The fill
+options are applied to aggregates based on order of appearance in the query.
 
-| fillOption | Description                                                                                                                                           |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NONE`     | Will not fill. In case there is no data, the time chunk will be skipped in the results. This means your table could potentially be missing intervals. |
-| `NULL`     | Fills with `null`                                                                                                                                     |
-| `PREV`     | Fills using the previous value                                                                                                                        |
-| `LINEAR`   | Fills by linear interpolation of the 2 surrounding points                                                                                             |
-| `x`        | Fills with the constant defined (replace the `x` by the value you want. For example `fill 100.05`                                                     |
+| fillOption | Description                                                                                                                                        |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NONE`     | No fill applied. If there is no data, the time chunk will be skipped in the results. This means your table could potentially be missing intervals. |
+| `NULL`     | Fills with `null`                                                                                                                                  |
+| `PREV`     | Fills using the previous value                                                                                                                     |
+| `LINEAR`   | Fills by linear interpolation of the 2 surrounding points                                                                                          |
+| `x`        | Fills with the constant defined (replace the `x` by the value you want. For example `FILL 100.05`                                                  |
 
 ## Examples
 
-Consider the following `prices` table
+Consider an example table named `prices`:
 
 | timestamp | price |
 | --------- | ----- |
@@ -35,8 +36,7 @@ Consider the following `prices` table
 | ...       | ...   |
 | tsn       | pn    |
 
-We could run the following to get the minimum, maximum and average price per
-hour using the following query:
+The following query returns the minimum, maximum and average price per hour:
 
 ```questdb-sql
 SELECT timestamp, min(price) min, max(price) max, avg(price) avg
@@ -44,7 +44,7 @@ FROM PRICES
 SAMPLE BY 1h;
 ```
 
-It would generally return result like this:
+The returned results look like this:
 
 | timestamp | min  | max  | average |
 | --------- | ---- | ---- | ------- |
@@ -52,9 +52,9 @@ It would generally return result like this:
 | ...       | ...  | ...  | ...     |
 | tsn       | minn | maxn | avgn    |
 
-However, in case there was no `PRICES` data for a given hour, your table would
-have time chunks missing. In the below example, there is no data to generate
-aggregates for `ts3`
+In the below example, there is no `price` data during the entire third hour. As
+there are missing values, an average aggregate cannot be calculated for this
+hour at `ts3`:
 
 | timestamp | min    | max    | average |
 | --------- | ------ | ------ | ------- |
@@ -65,18 +65,17 @@ aggregates for `ts3`
 | ...       | ...    | ...    | ...     |
 | tsn       | minn   | maxn   | avgn    |
 
-Here you can see that the third time chunk is missing. This is because there was
-no price update in the third hour. Let's see what different fill values would
-return:
+Based on this example, the following `FILL` strategies can be employed,
+demonstrating filling with `NULL`, a constant value, and the previous value:
 
-```questdb-sql
+```questdb-sql title="Using three fillOptions for filling missing data"
 SELECT timestamp, min(price) min, max(price) max, avg(price) avg
 FROM PRICES
 SAMPLE BY 1h
-FILL(null, 0, prev);
+FILL(NULL, 0, PREV);
 ```
 
-would return the following
+This query returns the following results:
 
 | timestamp | min    | max  | average |
 | --------- | ------ | ---- | ------- |
@@ -87,16 +86,17 @@ would return the following
 | ...       | ...    | ...  | ...     |
 | tsn       | minn   | maxn | avgn    |
 
-And the following:
+This query demonstrates the remaining `fillOptions` using a constant value and
+linear interpolation:
 
 ```questdb-sql
 SELECT timestamp, min(price) min, avg(price) avg
 FROM PRICES
 SAMPLE BY 1h
-FILL(25.5, linear);
+FILL(25.5, LINEAR);
 ```
 
-Would return:
+The results of this query look like the following:
 
 | timestamp | min    | average         |
 | --------- | ------ | --------------- |

--- a/docs/reference/sql/fill.md
+++ b/docs/reference/sql/fill.md
@@ -19,10 +19,10 @@ options are applied to aggregates based on order of appearance in the query.
 | fillOption | Description                                                                                                                                        |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `NONE`     | No fill applied. If there is no data, the time chunk will be skipped in the results. This means your table could potentially be missing intervals. |
-| `NULL`     | Fills with `null`                                                                                                                                  |
+| `NULL`     | Fills with `NULL`                                                                                                                                  |
 | `PREV`     | Fills using the previous value                                                                                                                     |
 | `LINEAR`   | Fills by linear interpolation of the 2 surrounding points                                                                                          |
-| `x`        | Fills with the constant defined (replace the `x` by the value you want. For example `FILL 100.05`                                                  |
+| `x`        | Fills with a constant value - where `x` is the desired value, for example `FILL(100.05)`                                                  |
 
 ## Examples
 
@@ -81,7 +81,7 @@ This query returns the following results:
 | --------- | ------ | ---- | ------- |
 | ts1       | min1   | max1 | avg1    |
 | ts2       | min2   | max2 | avg2    |
-| `ts3`     | `NULL` | `0`  | `avg2`  |
+| `ts3`     | `null` | `0`  | `avg2`  |
 | ts4       | min4   | max4 | avg4    |
 | ...       | ...    | ...  | ...     |
 | tsn       | minn   | maxn | avgn    |

--- a/docs/reference/sql/sample-by.md
+++ b/docs/reference/sql/sample-by.md
@@ -8,6 +8,9 @@ description: SAMPLE BY SQL keyword reference documentation.
 aggregates of homogeneous time chunks as part of a
 [SELECT statement](/docs/reference/sql/select/).
 
+Users performing `SAMPLE BY` queries on datasets __with missing data__ may make use
+of the [FILL](/docs/reference/sql/fill/) keyword to specify a fill behavior.
+
 :::note
 
 To use `SAMPLE BY`, one column needs to be designated as `timestamp`. Find out


### PR DESCRIPTION
__Improvements:__
* Add FILL reference in SAMPLE BY page
* Minor cleanup to FILL docs

__Open Questions:__
- [ ] Are parens necessary in `FILL(fillOptions)`? If so, the diagram needs to be updated

closes https://github.com/questdb/questdb/issues/785