### PR TITLE
chore: typo fix, reorder appearance of TCP and UDP for Influx line

### DIFF
--- a/docs/develop/insert-data.md
+++ b/docs/develop/insert-data.md
@@ -29,9 +29,9 @@ QuestDB implements InfluxDB line protocol which is accessible by default on TCP
 port `9009`. This allows using QuestDB as a drop-in replacement for InfluxDB and
 others implementing the protocol. Configuration settings for ingestion using
 this protocol can be set for for
-[Influx line over UDP](/docs/reference/configuration#influxdb-line-protocol-udp)
+[Influx line over TCP](/docs/reference/configuration#influxdb-line-protocol-tcp)
 and
-[Influx line over TCP](/docs/reference/configuration#influxdb-line-protocol-tcp).
+[Influx line over UDP](/docs/reference/configuration#influxdb-line-protocol-udp).
 
 More information on the InfluxDB line protocol implementation with details on
 message format, ports, authentication and examples can be found on the

--- a/docs/third-party-tools/telegraf.md
+++ b/docs/third-party-tools/telegraf.md
@@ -6,9 +6,9 @@ description:
 ---
 
 [Telegraf](https://docs.influxdata.com/telegraf/v1.17/) is a client for
-collecting metrics from many inputs and has support for and sending it on to
-various outputs. It is plugin-driven for the collection and delivery of data, so
-it is easily configurable and customizable. Telegraf is compiled as a standalone
+collecting metrics from many inputs and has support for sending it on to various
+outputs. It is plugin-driven for the collection and delivery of data, so it is
+easily configurable and customizable. Telegraf is compiled as a standalone
 binary, which means there are no external dependencies required to manage.
 
 QuestDB supports ingesting from Telegraf over both TCP and UDP. This page


### PR DESCRIPTION
Minor typo fix in Influx guide, reorder appearance of protocols