### PR TITLE
chore: improve readability of TOC in functions pages

### DIFF
--- a/docs/reference/function/aggregation.md
+++ b/docs/reference/function/aggregation.md
@@ -6,21 +6,18 @@ description: Aggregation functions reference documentation.
 
 ## avg
 
-`avg(value)` calculates simple average of values
+`avg(value)` calculates simple average of values ignoring missing data (e.g
+`null` values).
 
-### Arguments
+**Parameters:**
 
 - `value` is any numeric value.
 
-### Description
-
-`avg(value)` averages values ignoring missing data (e.g `null` values).
-
-### Return value
+**Return value:**
 
 Return value type is `double`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Average transaction amount"
 SELECT avg(amount) FROM transactions;
@@ -42,21 +39,17 @@ SELECT payment_type, avg(amount) FROM transactions;
 
 ## count
 
-`count()` or `count(*)` - counts rows.
+`count()` or `count(*)` - counts rows irrespective of underlying data.
 
-### Arguments
+**Parameters:**
 
 - `count` does not require arguments.
 
-### Description
-
-`count()` counts rows, irrespective of underlying data.
-
-### Return value
+**Return value:**
 
 Return value type is `long`.
 
-### Examples
+**Examples:**
 
 - Count of rows in the transactions table.
 
@@ -88,25 +81,20 @@ SELECT payment_type, count() FROM transactions;
 
 ## haversine_dist_deg
 
-`haversine_dist_deg(lat, lon, ts)` - traveled distance for a series of lat/lon
-points.
+`haversine_dist_deg(lat, lon, ts)` - calculates the traveled distance for a
+series of latitude and longitude points.
 
-### Arguments
+**Parameters:**
 
 - `lat` is the latitude expressed as degrees in decimal format (`double`)
 - `lon` is the longitude expressed as degrees in decimal format (`double`)
 - `ts` is the `timestamp` for the data point
 
-### Description
-
-This is an aggregatation function that calculates the traveled distance for a
-series of lat/lon points.
-
-### Return value
+**Return value:**
 
 Return value type is `double`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Calculate the aggregate traveled distance for each car_id"
 SELECT car_id, haversine_dist_deg(lat, lon, k)
@@ -115,25 +103,21 @@ SELECT car_id, haversine_dist_deg(lat, lon, k)
 
 ## ksum
 
-`ksum(value)` - adds values using Kahan algorithm.
-
-### Arguments
-
-- `value` is any numeric value.
-
-### Description
-
-`ksum(value)` adds values ignoring missing data (e.g `null` values). Values are
-added using the
+`ksum(value)` - adds values ignoring missing data (e.g `null` values). Values
+are added using the
 
 [Kahan compensated sum algorithm](https://en.wikipedia.org/wiki/Kahan_summation_algorithm).
 This is only beneficial for floating-point values such as `float` or `double`.
 
-### Return value
+**Parameters:**
+
+- `value` is any numeric value.
+
+**Return value:**
 
 Return value type is the same as the type of the argument.
 
-### Examples
+**Examples:**
 
 ```questdb-sql
 SELECT ksum(a)
@@ -146,21 +130,18 @@ FROM (SELECT rnd_double() a FROM long_sequence(100));
 
 ## max
 
-`max(value)` - finds the highest value.
+`max(value)` - returns the highest value ignoring missing data (e.g `null`
+values).
 
-### Arguments
+**Parameters:**
 
 - `value` is any numeric value
 
-### Description
-
-`max(value)` finds the highest value ignoring missing data (e.g `null` values).
-
-### Return value
+**Return value:**
 
 Return value type is the same as the type of the argument.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Highest transaction amount"
 SELECT max(amount) FROM transactions;
@@ -182,21 +163,18 @@ SELECT payment_type, max(amount) FROM transactions;
 
 ## min
 
-`min(value)` - finds the lowest value.
+`min(value)` - returns the lowest value ignoring missing data (e.g `null`
+values).
 
-### Arguments
+**Parameters:**
 
 - `value` is any numeric value
 
-### Description
-
-`min(value)` finds the lowest value ignoring missing data (e.g `null` values).
-
-### Return value
+**Return value:**
 
 Return value type is the same as the type of the argument.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Lowest transaction amount"
 SELECT min(amount) FROM transactions;
@@ -218,56 +196,20 @@ SELECT payment_type, min(amount) FROM transactions;
 
 ## nsum
 
-`nsum(value)` - adds values using Neumaier algorithm.
-
-### Arguments
-
-- `value` is any numeric value.
-
-### Description
-
-`nsum(value)` adds values ignoring missing data (e.g `null` values). Values are
-added using the
-
+`nsum(value)` - adds values ignoring missing data (e.g `null` values). Values
+are added using the
 [Neumaier sum algorithm](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements).
 This is only beneficial for floating-point values such as `float` or `double`.
 
-### Return value
-
-Return value type is the same as the type of the argument.
-
-### Examples
-
-```questdb-sql
-SELECT nsum(a)
-FROM (SELECT rnd_double() a FROM long_sequence(100));
-```
-
-| nsum             |
-| ---------------- |
-| 49.5442334742831 |
-
-## nsum
-
-`nsum(value)` - adds values using Neumaier algorithm.
-
-### Arguments
+**Parameters:**
 
 - `value` is any numeric value.
 
-### Description
-
-`nsum(value)` adds values ignoring missing data (e.g `null` values). Values are
-added using the
-
-[Neumaier sum algorithm](https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements).
-This is only beneficial for floating-point values such as `float` or `double`.
-
-### Return value
+**Return value:**
 
 Return value type is the same as the type of the argument.
 
-### Examples
+**Examples:**
 
 ```questdb-sql
 SELECT nsum(a)
@@ -280,21 +222,17 @@ FROM (SELECT rnd_double() a FROM long_sequence(100));
 
 ## sum
 
-`sum(value)` - adds values.
+`sum(value)` - adds values ignoring missing data (e.g `null` values).
 
-### Arguments
+**Parameters:**
 
 - `value` is any numeric value.
 
-### Description
-
-`sum(value)` adds values ignoring missing data (e.g `null` values).
-
-### Return value
+**Return value:**
 
 Return value type is the same as the type of the argument.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Sum all quantities in the transactions table"
 SELECT sum(quantity) FROM transactions;

--- a/docs/reference/function/date-time.md
+++ b/docs/reference/function/date-time.md
@@ -7,22 +7,19 @@ description: Date and time functions reference documentation.
 ## systimestamp
 
 `systimestamp()` - offset from UTC Epoch in microseconds.
-
-### Arguments
-
-- `systimestamp()` does not require arguments.
-
-### Description
-
 Calculates `UTC timestamp` using system's real time clock. The value is affected
 by discontinuous jumps in the system time (e.g., if the system administrator
 manually changes the system time).
 
-### Return value
+__Parameters:__
+
+- `systimestamp()` does not accept parameters.
+
+__Return value:__
 
 Return value type is `timestamp`.
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Insert current system timestamp"
 INSERT INTO readings
@@ -38,21 +35,19 @@ VALUES(systimestamp(), 123.5);
 `sysdate()` - returns the timestamp of the host system as a `date` with
 `millisecond` precision.
 
-### Arguments
-
-- `sysdate()` does not require arguments.
-
-### Description
-
 Calculates `UTC date` with millisecond precision using system's real time clock.
 The value is affected by discontinuous jumps in the system time (e.g., if the
 system administrator manually changes the system time).
 
-### Return value
+__Parameters:__
+
+- `sysdate()` does not accept parameters.
+
+__Return value:__
 
 Return value type is `date`.
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Insert current system date along with a value"
 INSERT INTO readings
@@ -72,12 +67,6 @@ WHERE date_time > sysdate() - 60000000L;
 
 `now()` - offset from UTC Epoch in microseconds.
 
-### Arguments
-
-- `now()` does not require arguments.
-
-### Description
-
 Calculates `UTC timestamp` using system's real time clock. Unlike `sysdatetime()`,
 it does not change within the query execution timeframe and should be used in
 WHERE clause to filter designated timestamp column relative to current time, i.e.:
@@ -85,11 +74,15 @@ WHERE clause to filter designated timestamp column relative to current time, i.e
 * `SELECT now() FROM long_sequence(200)` will return the same timestamp for all rows
 * `SELECT systimestamp() FROM long_sequence(200)` will have new timestamp values for each row
 
-### Return value
+__Parameters:__
+
+- `now()` does not accept parameters.
+
+__Return value:__
 
 Return value type is `timestamp`.
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Filter records to created within last day"
 SELECT created, origin FROM telemetry
@@ -120,14 +113,6 @@ WHERE date_time > now() - 60000000L;
 `to_timestamp(string, format)` - converts string to `timestamp` by using the
 supplied `format` to extract the value.
 
-### Arguments
-
-- `string` is any string that represents a date and/or time.
-- `format` is a string that describes the `timestamp format` in which `string`
-  is expressed.
-
-### Description
-
 Will convert a `string` to `timestamp` using the format definition passed as a
 parameter. When the `format` definition does not match the `string` input, the
 result will be `null`.
@@ -135,11 +120,17 @@ result will be `null`.
 For more information about recognized timestamp formats, see the
 [date and timestamp format section](#date-and-timestamp-format).
 
-### Return value
+__Parameters:__
+
+- `string` is any string that represents a date and/or time.
+- `format` is a string that describes the `timestamp format` in which `string`
+  is expressed.
+
+__Return value:__
 
 Return value type is `timestamp`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="string matches format"
 SELECT to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss')
@@ -173,14 +164,6 @@ values(to_timestamp('2019-12-12T12:15', 'yyyy-MM-ddTHH:mm'), 123.5);
 `to_date(string, format)` - converts string to `date` by using the supplied
 `format` to extract the value.
 
-### Arguments
-
-- `string` is any string that represents a date and/or time.
-- `format` is a string that describes the `date format` in which `string` is
-  expressed.
-
-### Description
-
 Will convert a `string` to `date` using the format definition passed as a
 parameter. When the `format` definition does not match the `string` input, the
 result will be `null`.
@@ -188,11 +171,18 @@ result will be `null`.
 For more information about recognized timestamp formats, see the
 [date and timestamp format section](#date-and-timestamp-format).
 
-### Return value
+
+__Parameters:__
+
+- `string` is any string that represents a date and/or time.
+- `format` is a string that describes the `date format` in which `string` is
+  expressed.
+
+__Return value:__
 
 Return value type is `date`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="string matches format"
 SELECT to_date('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss')
@@ -226,13 +216,6 @@ values(to_date('2019-12-12T12:15', 'yyyy-MM-ddTHH:mm'), 123.5);
 `to_str(value, format)` - converts date or timestamp value to a string in the
 specified format
 
-### Arguments
-
-- `value` is any `date` or `timestamp`
-- `format` is a timestamp format.
-
-### Description
-
 Will convert a date or timestamp value to a string using the format definition
 passed as a parameter. When elements in the `format` definition are
 unrecognized, they will be passed-through as string.
@@ -240,11 +223,17 @@ unrecognized, they will be passed-through as string.
 For more information about recognized timestamp formats, see the
 [date and timestamp format section](#date-and-timestamp-format).
 
-### Return value
+
+__Parameters:__
+
+- `value` is any `date` or `timestamp`
+- `format` is a timestamp format.
+
+__Return value:__
 
 Return value type is `string`
 
-### Examples
+__Examples:__
 
 - Basic example
 
@@ -268,24 +257,21 @@ SELECT to_str(systimestamp(), 'yyyy-MM-dd gooD DAY 123') FROM long_sequence(1);
 
 ## dateadd
 
-`dateadd(period, n, startDate)` - adds time to a date or timestamp
+`dateadd(period, n, startDate)` - adds `n` `period` to `startDate`.
 
-### Arguments
+__Parameters:__
 
 - `period` is a char. Period to be added. Available periods are `s`, `m`, `h`,
   `d`, `M`, `y`.
 - `n` is an int. Number of periods to add.
 - `startDate` is a timestamp or date. Timestamp to add the periods to.
 
-### Description
 
-Adds `n` `period` to `startDate`.
-
-### Return value
+__Return value:__
 
 Return value type is `timestamp`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Adding hours"
 SELECT systimestamp(), dateadd('h', 2, systimestamp())
@@ -316,24 +302,20 @@ FROM long_sequence(1);
 
 ## datediff
 
-`datediff(period, date1, date2)` - returns the difference between two dates or
-timestamps
+`datediff(period, date1, date2)` - returns the absolute number of `period` between `date1` and `date2`.
 
-### Arguments
+__Parameters:__
 
 - `period` is a char. Period to be added. Available periods are `s`, `m`, `h`,
   `d`, `M`, `y`.
 - `date1` and `date2` are date or timestamp. Dates to compare
 
-### Description
 
-Returns the absolute number of `period` between `date1` and `date2`.
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Difference in days"
 select datediff(
@@ -361,22 +343,18 @@ from long_sequence(1);
 
 ## millis
 
-`millis(value)` - milliseconds of the second on a 0-999 scale
+`millis(value)` - returns the `millis` of the second for a given date or timestamp
+from `0` to `999`
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`millis(value)` returns the `millis` of the second for a given date or timestamp
-from 0 to 999
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Millis of the second"
 SELECT millis(
@@ -402,22 +380,18 @@ select millis(ts), count() from transactions;
 
 ## micros
 
-`micros(value)` - microseconds of the millisecond on a 0-999 scale
+`micros(value)` - returns the `micros` of the millisecond for a given date or
+timestamp from `0` to `999`
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`micros(value)` returns the `micros` of the millisecond for a given date or
-timestamp from 0 to 999
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Micros of the second"
 SELECT micros(to_timestamp('2020-03-01:15:43:21.123456', 'yyyy-MM-dd:HH:mm:ss.SSSUUU'))
@@ -442,22 +416,18 @@ select micros(ts), count() from transactions;
 
 ## second
 
-`second(value)` - second of the minute on a 0-59 scale
+`second(value)` - returns the `second` of the minute for a given date or timestamp
+from `0` to `59`
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`second(value)` returns the `second` of the minute for a given date or timestamp
-from 0 to 59
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Second of the minute"
 SELECT second(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -482,22 +452,18 @@ select second(ts), count() from transactions;
 
 ## minute
 
-`minute(value)` - minute of hour on a 0-59 scale
+`minute(value)` - returns the `minute` of the hour for a given date or timestamp
+from `0` to `59`
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`minute(value)` returns the `minute` of the hour for a given date or timestamp
-from 0 to 59
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Minute of the hour"
 SELECT minute(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -522,22 +488,18 @@ select minute(ts), count() from transactions;
 
 ## hour
 
-`hour(value)` - hour of day on a 0-23 scale
+`hour(value)` - returns the `hour` of day for a given date or timestamp from `0` to
+`23`
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`hour(value)` returns the `hour` of day for a given date or timestamp from 0 to
-23
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Hour of the day"
 SELECT hour(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -562,22 +524,18 @@ select hour(ts), count() from transactions;
 
 ## day
 
-`day(value)` - day of month on a 1 to 31 scale
+`day(value)` - returns the `day` of month for a given date or timestamp from `0` to
+`23`
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`day(value)` returns the `day` of month for a given date or timestamp from 0 to
-23
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Day of the month"
 SELECT day(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -602,22 +560,18 @@ select day(ts), count() from transactions;
 
 ## month
 
-`month(value)` - month of year on a 1-12 scale
+`month(value)` - returns the `month` of year for a given date or timestamp from `1`
+to `12`
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`month(value)` returns the `month` of year for a given date or timestamp from 1
-to 12
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Month of the year"
 SELECT month(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -642,21 +596,17 @@ select month(ts), count() from transactions;
 
 ## year
 
-`year(value)` - year of a timestamp
+`year(value)` - returns the `year` for a given date or timestamp
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`year(value)` returns the `year` for a given date or timestamp
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql title="Year"
 SELECT year(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -679,22 +629,18 @@ select month(ts), count() from transactions;
 
 ## is_leap_year
 
-`is_leap_year(value)` - flags a leap year
+`is_leap_year(value)` - returns `true` if the `year` of `value` is a leap year,
+`false` otherwise.
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`is_leap_year(value)` returns `true` if the `year` of `value` is a leap year,
-`false` otherwise.
-
-### Return value
+__Return value:__
 
 Return value type is `boolean`
 
-### Examples
+__Examples:__
 
 ```questdb-sql
 select year(ts), is_leap_year(ts) from myTable;
@@ -711,21 +657,17 @@ select year(ts), is_leap_year(ts) from myTable;
 
 ## days_in_month
 
-`days_in_month(value)` - counts days in month
+`days_in_month(value)` - returns the number of days in a month from a provided timestamp or date.
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`days_in_month(value)` returns the count of days in a the month.
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql
 select month(ts), days_in_month(ts) from myTable;
@@ -741,22 +683,18 @@ select month(ts), days_in_month(ts) from myTable;
 
 ## day_of_week
 
-`day_of_week(value)` - day number in the week starting on Monday
+`day_of_week(value)` - returns the day number in a week from `1` (Monday) to `7`
+(Sunday)
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`day_of_week(value)` returns the day number in a week from 1 (Monday) to 7
-(Sunday)
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql
 select to_str(ts,'EE'),day_of_week(ts) from myTable;
@@ -774,22 +712,18 @@ select to_str(ts,'EE'),day_of_week(ts) from myTable;
 
 ## day_of_week_sunday_first
 
-`day_of_week_sunday_first(value)` - day number in the week starting on Sunday
+`day_of_week_sunday_first(value)` - returns the day number in a week from `1`
+(Sunday) to `7` (Saturday)
 
-### Parameters
+__Parameters:__
 
 - `value` is any `timestamp` or `date`
 
-### Description
-
-`day_of_week_sunday_first(value)` returns the day number in a week from 1
-(Sunday) to 7 (Saturday)
-
-### Return value
+__Return value:__
 
 Return value type is `int`
 
-### Examples
+__Examples:__
 
 ```questdb-sql
 select to_str(ts,'EE'),day_of_week_sunday_first(ts) from myTable;

--- a/docs/reference/function/date-time.md
+++ b/docs/reference/function/date-time.md
@@ -6,20 +6,20 @@ description: Date and time functions reference documentation.
 
 ## systimestamp
 
-`systimestamp()` - offset from UTC Epoch in microseconds.
-Calculates `UTC timestamp` using system's real time clock. The value is affected
-by discontinuous jumps in the system time (e.g., if the system administrator
+`systimestamp()` - offset from UTC Epoch in microseconds. Calculates
+`UTC timestamp` using system's real time clock. The value is affected by
+discontinuous jumps in the system time (e.g., if the system administrator
 manually changes the system time).
 
-__Parameters:__
+**Arguments:**
 
-- `systimestamp()` does not accept parameters.
+- `systimestamp()` does not accept arguments.
 
-__Return value:__
+**Return value:**
 
 Return value type is `timestamp`.
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Insert current system timestamp"
 INSERT INTO readings
@@ -39,15 +39,15 @@ Calculates `UTC date` with millisecond precision using system's real time clock.
 The value is affected by discontinuous jumps in the system time (e.g., if the
 system administrator manually changes the system time).
 
-__Parameters:__
+**Arguments:**
 
-- `sysdate()` does not accept parameters.
+- `sysdate()` does not accept arguments.
 
-__Return value:__
+**Return value:**
 
 Return value type is `date`.
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Insert current system date along with a value"
 INSERT INTO readings
@@ -67,22 +67,25 @@ WHERE date_time > sysdate() - 60000000L;
 
 `now()` - offset from UTC Epoch in microseconds.
 
-Calculates `UTC timestamp` using system's real time clock. Unlike `sysdatetime()`,
-it does not change within the query execution timeframe and should be used in
-WHERE clause to filter designated timestamp column relative to current time, i.e.:
+Calculates `UTC timestamp` using system's real time clock. Unlike
+`sysdatetime()`, it does not change within the query execution timeframe and
+should be used in WHERE clause to filter designated timestamp column relative to
+current time, i.e.:
 
-* `SELECT now() FROM long_sequence(200)` will return the same timestamp for all rows
-* `SELECT systimestamp() FROM long_sequence(200)` will have new timestamp values for each row
+- `SELECT now() FROM long_sequence(200)` will return the same timestamp for all
+  rows
+- `SELECT systimestamp() FROM long_sequence(200)` will have new timestamp values
+  for each row
 
-__Parameters:__
+**Arguments:**
 
-- `now()` does not accept parameters.
+- `now()` does not accept arguments.
 
-__Return value:__
+**Return value:**
 
 Return value type is `timestamp`.
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Filter records to created within last day"
 SELECT created, origin FROM telemetry
@@ -113,24 +116,24 @@ WHERE date_time > now() - 60000000L;
 `to_timestamp(string, format)` - converts string to `timestamp` by using the
 supplied `format` to extract the value.
 
-Will convert a `string` to `timestamp` using the format definition passed as a
-parameter. When the `format` definition does not match the `string` input, the
+Will convert a `string` to `timestamp` using the format definition passed as an
+argument. When the `format` definition does not match the `string` input, the
 result will be `null`.
 
 For more information about recognized timestamp formats, see the
 [date and timestamp format section](#date-and-timestamp-format).
 
-__Parameters:__
+**Arguments:**
 
 - `string` is any string that represents a date and/or time.
 - `format` is a string that describes the `timestamp format` in which `string`
   is expressed.
 
-__Return value:__
+**Return value:**
 
 Return value type is `timestamp`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="string matches format"
 SELECT to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss')
@@ -164,25 +167,24 @@ values(to_timestamp('2019-12-12T12:15', 'yyyy-MM-ddTHH:mm'), 123.5);
 `to_date(string, format)` - converts string to `date` by using the supplied
 `format` to extract the value.
 
-Will convert a `string` to `date` using the format definition passed as a
-parameter. When the `format` definition does not match the `string` input, the
+Will convert a `string` to `date` using the format definition passed as an
+argument. When the `format` definition does not match the `string` input, the
 result will be `null`.
 
 For more information about recognized timestamp formats, see the
 [date and timestamp format section](#date-and-timestamp-format).
 
-
-__Parameters:__
+**Arguments:**
 
 - `string` is any string that represents a date and/or time.
 - `format` is a string that describes the `date format` in which `string` is
   expressed.
 
-__Return value:__
+**Return value:**
 
 Return value type is `date`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="string matches format"
 SELECT to_date('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss')
@@ -217,23 +219,22 @@ values(to_date('2019-12-12T12:15', 'yyyy-MM-ddTHH:mm'), 123.5);
 specified format
 
 Will convert a date or timestamp value to a string using the format definition
-passed as a parameter. When elements in the `format` definition are
+passed as an argument. When elements in the `format` definition are
 unrecognized, they will be passed-through as string.
 
 For more information about recognized timestamp formats, see the
 [date and timestamp format section](#date-and-timestamp-format).
 
-
-__Parameters:__
+**Arguments:**
 
 - `value` is any `date` or `timestamp`
 - `format` is a timestamp format.
 
-__Return value:__
+**Return value:**
 
 Return value type is `string`
 
-__Examples:__
+**Examples:**
 
 - Basic example
 
@@ -259,19 +260,18 @@ SELECT to_str(systimestamp(), 'yyyy-MM-dd gooD DAY 123') FROM long_sequence(1);
 
 `dateadd(period, n, startDate)` - adds `n` `period` to `startDate`.
 
-__Parameters:__
+**Arguments:**
 
 - `period` is a char. Period to be added. Available periods are `s`, `m`, `h`,
   `d`, `M`, `y`.
 - `n` is an int. Number of periods to add.
 - `startDate` is a timestamp or date. Timestamp to add the periods to.
 
-
-__Return value:__
+**Return value:**
 
 Return value type is `timestamp`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Adding hours"
 SELECT systimestamp(), dateadd('h', 2, systimestamp())
@@ -302,20 +302,20 @@ FROM long_sequence(1);
 
 ## datediff
 
-`datediff(period, date1, date2)` - returns the absolute number of `period` between `date1` and `date2`.
+`datediff(period, date1, date2)` - returns the absolute number of `period`
+between `date1` and `date2`.
 
-__Parameters:__
+**Arguments:**
 
 - `period` is a char. Period to be added. Available periods are `s`, `m`, `h`,
   `d`, `M`, `y`.
 - `date1` and `date2` are date or timestamp. Dates to compare
 
-
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Difference in days"
 select datediff(
@@ -343,18 +343,18 @@ from long_sequence(1);
 
 ## millis
 
-`millis(value)` - returns the `millis` of the second for a given date or timestamp
-from `0` to `999`
+`millis(value)` - returns the `millis` of the second for a given date or
+timestamp from `0` to `999`
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Millis of the second"
 SELECT millis(
@@ -383,15 +383,15 @@ select millis(ts), count() from transactions;
 `micros(value)` - returns the `micros` of the millisecond for a given date or
 timestamp from `0` to `999`
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Micros of the second"
 SELECT micros(to_timestamp('2020-03-01:15:43:21.123456', 'yyyy-MM-dd:HH:mm:ss.SSSUUU'))
@@ -416,18 +416,18 @@ select micros(ts), count() from transactions;
 
 ## second
 
-`second(value)` - returns the `second` of the minute for a given date or timestamp
-from `0` to `59`
+`second(value)` - returns the `second` of the minute for a given date or
+timestamp from `0` to `59`
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Second of the minute"
 SELECT second(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -455,15 +455,15 @@ select second(ts), count() from transactions;
 `minute(value)` - returns the `minute` of the hour for a given date or timestamp
 from `0` to `59`
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Minute of the hour"
 SELECT minute(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -488,18 +488,18 @@ select minute(ts), count() from transactions;
 
 ## hour
 
-`hour(value)` - returns the `hour` of day for a given date or timestamp from `0` to
-`23`
+`hour(value)` - returns the `hour` of day for a given date or timestamp from `0`
+to `23`
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Hour of the day"
 SELECT hour(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -524,18 +524,18 @@ select hour(ts), count() from transactions;
 
 ## day
 
-`day(value)` - returns the `day` of month for a given date or timestamp from `0` to
-`23`
+`day(value)` - returns the `day` of month for a given date or timestamp from `0`
+to `23`
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Day of the month"
 SELECT day(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -560,18 +560,18 @@ select day(ts), count() from transactions;
 
 ## month
 
-`month(value)` - returns the `month` of year for a given date or timestamp from `1`
-to `12`
+`month(value)` - returns the `month` of year for a given date or timestamp from
+`1` to `12`
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Month of the year"
 SELECT month(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -598,15 +598,15 @@ select month(ts), count() from transactions;
 
 `year(value)` - returns the `year` for a given date or timestamp
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql title="Year"
 SELECT year(to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'))
@@ -632,15 +632,15 @@ select month(ts), count() from transactions;
 `is_leap_year(value)` - returns `true` if the `year` of `value` is a leap year,
 `false` otherwise.
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `boolean`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql
 select year(ts), is_leap_year(ts) from myTable;
@@ -657,17 +657,18 @@ select year(ts), is_leap_year(ts) from myTable;
 
 ## days_in_month
 
-`days_in_month(value)` - returns the number of days in a month from a provided timestamp or date.
+`days_in_month(value)` - returns the number of days in a month from a provided
+timestamp or date.
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql
 select month(ts), days_in_month(ts) from myTable;
@@ -686,15 +687,15 @@ select month(ts), days_in_month(ts) from myTable;
 `day_of_week(value)` - returns the day number in a week from `1` (Monday) to `7`
 (Sunday)
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql
 select to_str(ts,'EE'),day_of_week(ts) from myTable;
@@ -715,15 +716,15 @@ select to_str(ts,'EE'),day_of_week(ts) from myTable;
 `day_of_week_sunday_first(value)` - returns the day number in a week from `1`
 (Sunday) to `7` (Saturday)
 
-__Parameters:__
+**Arguments:**
 
 - `value` is any `timestamp` or `date`
 
-__Return value:__
+**Return value:**
 
 Return value type is `int`
 
-__Examples:__
+**Examples:**
 
 ```questdb-sql
 select to_str(ts,'EE'),day_of_week_sunday_first(ts) from myTable;

--- a/docs/reference/function/meta.md
+++ b/docs/reference/function/meta.md
@@ -6,21 +6,17 @@ description: Table and database metadata function reference documentation.
 
 ## all_tables
 
-`all_tables()` returns a list of tables.
+`all_tables()` returns all tables in the database.
 
-### Arguments
+**Parameters:**
 
 - `all_tables()` does not require arguments.
 
-### Description
-
-Returns all tables in the database.
-
-### Return value
+**Return value:**
 
 Returns a `table`.
 
-### Examples
+**Examples:**
 
 - Get all tables in the database
 
@@ -64,22 +60,18 @@ all_tables() ORDER BY tableName DESC;
 
 `table_columns('tableName')` returns the schema of a table
 
-### Arguments
+**Parameters:**
 
 - `tableName` is the name of an existing table as a string
 
-### Description
-
-Returns the schema of the target table.
-
-### Return value
+**Return value:**
 
 Returns a `table` with two columns:
 
 - `columnName` - name of the available columns in the table
 - `columnType` - type of the column
 
-### Examples
+**Examples:**
 
 - Get all columns in the table
 

--- a/docs/reference/function/numeric.md
+++ b/docs/reference/function/numeric.md
@@ -4,12 +4,44 @@ sidebar_label: Numeric
 description: Numeric function reference documentation.
 ---
 
+## abs
+
+`abs(value)` return the absolute value. The behavior of `abs` is as follows:
+
+- When the input `value` is positive, `abs` returns `value`
+- When the input `value` is negative, `abs` returns `- value`
+- When the input `value` is `0`, `abs` returns `0`
+
+**Arguments:**
+
+- `value` is any numeric value.
+
+**Return value:**
+
+Return value type is `double`.
+
+**Examples:**
+
+```questdb-sql
+SELECT
+    x - 2 a,
+    abs(x -2)
+FROM long_sequence(3);
+```
+
+| a   | abs |
+| --- | --- |
+| -1  | 1   |
+| 0   | 0   |
+| 1   | 1   |
+
 ## round
 
-`round(value, scale)` rounds a value to the specified scale using the "half up"
-method.
+`round(value, scale)` returns the **closest** value in the specified scale. It
+uses the "half up" tie-breaking method when the value is exactly halfway between
+the `round_up` and `round_down` values.
 
-### Arguments
+**Arguments:**
 
 - `value` is any numeric value.
 - `scale` is the number of decimal points returned. A negative scale means the
@@ -17,17 +49,11 @@ method.
   -1 means the number will be rounded to the nearest tens and +1 to the nearest
   tenths.
 
-### Description
-
-`round(value, scale)` returns the **closest** value in the specified scale. It
-uses the "half up" tie-breaking method when the value is exactly halfway between
-the `round_up` and `round_down` values.
-
-### Return value
+**Return value:**
 
 Return value type is `double`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql
 SELECT
@@ -55,7 +81,7 @@ FROM dbl;
 
 `round_down(value, scale)` - rounds a value down to the specified scale
 
-### Arguments
+**Arguments:**
 
 - `value` is any numeric value.
 - `scale` is the number of decimal points returned. A negative scale means the
@@ -63,15 +89,11 @@ FROM dbl;
   -1 means the number will be rounded to the nearest tens and +1 to the nearest
   tenths.
 
-### Description
-
-`round_up(value, scale)` rounds a value down to the specified scale.
-
-### Return value
+**Return value:**
 
 Return value type is `double`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql
 SELECT
@@ -95,56 +117,13 @@ FROM dbl;
 | 86.91359825  | 0        | 80       | 86      | 86.9    | 86.91   |
 | 376.3807766  | 400      | 370      | 376     | 376.3   | 376.38  |
 
-## round_up
-
-`round_up(value, scale)` - rounds a value up to the specified scale
-
-### Arguments
-
-- `value` is any numeric value.
-- `scale` is the number of decimal points returned. A negative scale means the
-  rounding will occur to a digit to the left of the decimal point. For example,
-  -1 means the number will be rounded to the nearest tens and +1 to the nearest
-  tenths.
-
-### Description
-
-`round_up(value, scale)` rounds a value up to the specified scale
-
-### Return value
-
-Return value type is `double`.
-
-### Examples
-
-```questdb-sql
-SELECT
-    d,
-    round_up(d, -2),
-    round_up(d, -1),
-    round_up(d,0),
-    round_up(d,1),
-    round_up(d,2)
-FROM dbl;
-```
-
-| d            | r_up-2 | r_up-1 | r_up0 | r_up1  | r_up2   |
-| ------------ | ------ | ------ | ----- | ------ | ------- |
-| -0.811905406 | -100   | -10    | -1    | -0.9   | -0.82   |
-| -5.002768547 | -100   | -10    | -6    | -5.1   | -5.01   |
-| -64.75487334 | -100   | -70    | -65   | -64.8  | -64.76  |
-| -926.531695  | -1000  | -930   | -927  | -926.6 | -926.54 |
-| 0.069361448  | 100    | 10     | 1     | 0.1    | 0.07    |
-| 4.003627053  | 100    | 10     | 5     | 4.1    | 4.01    |
-| 86.91359825  | 100    | 90     | 87    | 87     | 86.92   |
-| 376.3807766  | 400    | 380    | 377   | 376.4  | 376.39  |
-
 ## round_half_even
 
 `round_half_even(value, scale)` - returns the **closest** value in the specified
-scale using the "half to even" behaviour
+scale. It uses the "half up" tie-breaking method when the value is exactly
+halfway between the `round_up` and `round_down` values.
 
-### Arguments
+**Arguments:**
 
 - `value` is any numeric value.
 - `scale` is the number of decimal points returned. A negative scale means the
@@ -152,17 +131,11 @@ scale using the "half to even" behaviour
   -1 means the number will be rounded to the nearest tens and +1 to the nearest
   tenths.
 
-### Description
-
-`round_half_even(value, scale)` returns the **closest** value in the specified
-scale. It uses the "half up" tie-breaking method when the value is exactly
-halfway between the `round_up` and `round_down` values.
-
-### Return value
+**Return value:**
 
 Return value type is `double`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Tie-breaker behavior"
 SELECT
@@ -197,37 +170,42 @@ FROM dbl;
 | 86.91359825  | 100     | 90      | 87     | 86.9   | 86.91   |
 | 376.3807766  | 400     | 380     | 376    | 376.4  | 376.38  |
 
-## abs
+## round_up
 
-`abs(value)` return the absolute value.
+`round_up(value, scale)` - rounds a value up to the specified scale
 
-### Arguments
+**Arguments:**
 
 - `value` is any numeric value.
+- `scale` is the number of decimal points returned. A negative scale means the
+  rounding will occur to a digit to the left of the decimal point. For example,
+  -1 means the number will be rounded to the nearest tens and +1 to the nearest
+  tenths.
 
-### Description
-
-`abs(value)` behaves as follow
-
-- When the input `value` is positive, `abs` returns `value`
-- When the input `value` is negative, `abs` returns `- value`
-- When the input `value` is `0`, `abs` returns `0`
-
-### Return value
+**Return value:**
 
 Return value type is `double`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql
 SELECT
-    x - 2 a,
-    abs(x -2)
-FROM long_sequence(3);
+    d,
+    round_up(d, -2),
+    round_up(d, -1),
+    round_up(d,0),
+    round_up(d,1),
+    round_up(d,2)
+FROM dbl;
 ```
 
-| a   | abs |
-| --- | --- |
-| -1  | 1   |
-| 0   | 0   |
-| 1   | 1   |
+| d            | r_up-2 | r_up-1 | r_up0 | r_up1  | r_up2   |
+| ------------ | ------ | ------ | ----- | ------ | ------- |
+| -0.811905406 | -100   | -10    | -1    | -0.9   | -0.82   |
+| -5.002768547 | -100   | -10    | -6    | -5.1   | -5.01   |
+| -64.75487334 | -100   | -70    | -65   | -64.8  | -64.76  |
+| -926.531695  | -1000  | -930   | -927  | -926.6 | -926.54 |
+| 0.069361448  | 100    | 10     | 1     | 0.1    | 0.07    |
+| 4.003627053  | 100    | 10     | 5     | 4.1    | 4.01    |
+| 86.91359825  | 100    | 90     | 87    | 87     | 86.92   |
+| 376.3807766  | 400    | 380    | 377   | 376.4  | 376.39  |

--- a/docs/reference/function/random-value-generator.md
+++ b/docs/reference/function/random-value-generator.md
@@ -184,7 +184,9 @@ null,null,null,null,null
   `0x8000000000000000L` and `0x7fffffffffffffffL`.
 - `rnd_long(min, max, nanRate)` is used to generate long values in a specific
   range (for example only positive, or between 1 and 10), or to get occasional
-  `NaN` values along with int values. **Arguments:**
+  `NaN` values along with int values.
+
+**Arguments:**
 
 - `min`: is a `long` representing the lowest possible generated value
   (inclusive).

--- a/docs/reference/function/random-value-generator.md
+++ b/docs/reference/function/random-value-generator.md
@@ -4,8 +4,6 @@ sidebar_label: Random value generator
 description: Random value generator function reference documentation.
 ---
 
-## Overview
-
 The following functions have been created to help with our test suite. They are
 also useful for users testing QuestDB on specific workloads in order to quickly
 generate large test datasets that mimic the structure of their actual data.
@@ -33,7 +31,7 @@ QuestDB supports the following random generation functions:
 - [rnd_str](#rnd_str)
 - [rnd_bin](#rnd_bin)
 
-### Usage
+## Usage
 
 Random functions should be used for populating test tables only. They do not
 hold values in memory and calculations should not be performed at the same time
@@ -46,12 +44,12 @@ bad practice and will return inconsistent results.
 A better approach would be to populate a table and then run the query. So for
 example
 
-- `CREATE TABLE test(val double);` (create)
-- `INSERT INTO test SELECT * FROM (SELECT rnd_double() FROM long_sequence(10));`
-  (populate)
-- `SELECT round(val,2) FROM test;` (query)
+1. **create** - `CREATE TABLE test(val double);`
+2. **populate** -
+   `INSERT INTO test SELECT * FROM (SELECT rnd_double() FROM long_sequence(10));`
+3. **query** - `SELECT round(val,2) FROM test;`
 
-### Generating sequences
+## Generating sequences
 
 This page describes the functions to generate values. To generate sequences of
 values, please refer the page about
@@ -59,18 +57,14 @@ values, please refer the page about
 
 ## rnd_boolean
 
-`rnd_boolean()` - generates a random `boolean` value.
+`rnd_boolean()` - generates a random `boolean` value, either `true` or `false`,
+both having equal probability.
 
-### Description
-
-- `rnd_boolean()` is used to generate a random boolean, either `true` or
-  `false`, both having equal probability.
-
-### Return value
+**Return value:**
 
 Return value type is `boolean`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random boolean"
 SELECT
@@ -86,27 +80,23 @@ FROM (SELECT rnd_boolean() value FROM long_sequence(100));
 
 ## rnd_byte
 
-- `rnd_byte()` - generates a random `byte` value.
-- `rnd_byte(min, max)` - generates a random `byte` value within a range.
+- `rnd_byte()` - returns a random integer which can take any value between `0`
+  and `127`.
+- `rnd_byte(min, max)` - generates byte values in a specific range (for example
+  only positive, or between 1 and 10).
 
-### Arguments
+**Arguments:**
 
 - `min`: is a `byte` representing the lowest possible generated value
   (inclusive).
 - `max`: is a `byte` representing the highest possible generated value
   (inclusive).
 
-### Description
-
-`rnd_byte()` is used to return a random integer which can take any value between
-`0` and `127`. `rnd_int(min, max)` is used to generate byte values between in a
-specific range (for example only positive, or between 1 and 10).
-
-### Return value
+**Return value:**
 
 Return value type is `byte`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random byte"
 SELECT rnd_byte() FROM long_sequence(5);
@@ -120,29 +110,24 @@ SELECT rnd_byte(-1,1) FROM long_sequence(5);
 
 ## rnd_short
 
-- `rnd_short()` - generates a random `short` value.
-- `rnd_short(min, max)` - generates a random `short` value within a range.
+- `rnd_short()` - returns a random integer which can take any value between
+  `-32768` and `32767`.
+- `rnd_short(min, max)` - returns short values in a specific range (for example
+  only positive, or between 1 and 10). Supplying `min` above `max` will result
+  in an `invalid range` error.
 
-### Arguments
+**Arguments:**
 
 - `min`: is a `short` representing the lowest possible generated value
   (inclusive).
 - `max`: is a `short` representing the highest possible generated value
   (inclusive).
 
-### Description
-
-- `rnd_short()` is used to return a random integer which can take any value
-  between `-32768` and `32767`.
-- `rnd_int(min, max, nanRate)` is used to generate short values in a specific
-  range (for example only positive, or between 1 and 10). Supplying `min` above
-  `max` will result in an `invalid range` error.
-
-### Return value
+**Return value:**
 
 Return value type is `short`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random short"
 SELECT rnd_short() FROM long_sequence(5);
@@ -156,11 +141,13 @@ SELECT rnd_short(-1,1) FROM long_sequence(5);
 
 ## rnd_int
 
-- `rnd_int()` - generates a random `int` value.
-- `rnd_int(min, max, nanRate)` - generates a random `int` between `min` and
-  `max` (both included) with a proportion of `NaN` values defined by `nanRate`.
+- `rnd_int()` is used to return a random integer which can take any value
+  between `-2147483648` and `2147483647`.
+- `rnd_int(min, max, nanRate)` is used to generate int values in a specific
+  range (for example only positive, or between 1 and 10), or to get occasional
+  `NaN` values along with int values.
 
-### Arguments
+**Arguments:**
 
 - `min`: is an `int` representing the lowest possible generated value
   (inclusive).
@@ -171,19 +158,11 @@ SELECT rnd_short(-1,1) FROM long_sequence(5);
   - `1`: Will only return `NaN`.
   - `N > 1`: On average, one in N generated values will be NaN.
 
-### Description
-
-- `rnd_int()` is used to return a random integer which can take any value
-  between `-2147483648` and `2147483647`.
-- `rnd_int(min, max, nanRate)` is used to generate int values in a specific
-  range (for example only positive, or between 1 and 10), or to get occasional
-  `NaN` values along with int values.
-
-### Return value
+**Return value:**
 
 Return value type is `int`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random int"
 SELECT rnd_int() FROM long_sequence(5)
@@ -201,11 +180,11 @@ null,null,null,null,null
 
 ## rnd_long
 
-- `rnd_long()` - generates a random `long` value.
-- `rnd_long(min, max, nanRate)` - generates a random `long` value within a range
-  which can be `NaN`.
-
-### Arguments
+- `rnd_long()` is used to return a random signed integer between
+  `0x8000000000000000L` and `0x7fffffffffffffffL`.
+- `rnd_long(min, max, nanRate)` is used to generate long values in a specific
+  range (for example only positive, or between 1 and 10), or to get occasional
+  `NaN` values along with int values. **Arguments:**
 
 - `min`: is a `long` representing the lowest possible generated value
   (inclusive).
@@ -216,19 +195,11 @@ null,null,null,null,null
   - `1`: Will only return `NaN`.
   - `N > 1`: On average, one in N generated values will be `NaN`.
 
-### Description
-
-- `rnd_long()` is used to return a random signed integer between
-  `0x8000000000000000L` and `0x7fffffffffffffffL`.
-- `rnd_long(min, max, nanRate)` is used to generate long values in a specific
-  range (for example only positive, or between 1 and 10), or to get occasional
-  `NaN` values along with int values.
-
-### Return value
+**Return value:**
 
 Return value type is `long`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random long"
 SELECT rnd_long() FROM long_sequence(5);
@@ -246,9 +217,9 @@ null,null,null,null,null
 
 ## rnd_long256
 
-- `rnd_long256()` - generates a random `long256` value.
+- `rnd_long256()` - generates a random `long256` value between 0 and 2^256.
 
-### Arguments
+**Arguments:**
 
 - `min`: is a `long256` representing the lowest possible generated value
   (inclusive).
@@ -259,16 +230,11 @@ null,null,null,null,null
   - `1`: Will only return `NaN`.
   - `N > 1`: On average, one in N generated values will be `NaN`.
 
-### Description
-
-- `rnd_long256()` is used to return a random `long256` value between 0 and
-  2^256.
-
-### Return value
+**Return value:**
 
 Return value type is `long256`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random long256"
 SELECT rnd_long256() FROM long_sequence(5);
@@ -284,27 +250,22 @@ SELECT rnd_long256() FROM long_sequence(5);
 
 ## rnd_float
 
-- `rnd_float()` - generates a random `float`.
-- `rnd_float(nanRate)` - generates a random `float` which can be `NaN`.
+- `rnd_float()` - generates a random **positive** `float` between 0 and 1.
+- `rnd_float(nanRate)` - generates a random **positive** `float` between 0 and 1
+  which will be `NaN` at a frequency defined by `nanRate`.
 
-### Arguments
+**Arguments:**
 
 - `nanRate` is an `int` defining the frequency of occurrence of `NaN` values:
 - `0`: No `NaN` will be returned.
 - `1`: Will only return `NaN`.
 - `N > 1`: On average, one in N generated values will be `NaN`.
 
-### Description
-
-- `rnd_float()` - generates a random **positive** `float` between 0 and 1.
-- `rnd_float(nanRate)` - generates a random **positive** `float` between 0 and 1
-  which will be `NaN` at a frequency defined by `nanRate`.
-
-### Return value
+**Return value:**
 
 Return value type is `float`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random float"
 SELECT rnd_float() FROM long_sequence(5);
@@ -318,27 +279,22 @@ SELECT rnd_float(2) FROM long_sequence(6);
 
 ## rnd_double
 
-- `rnd_double()` - generates a random `double`.
-- `rnd_double(nanRate)` - generates a random `double` which can be `NaN`.
+- `rnd_double()` - generates a random **positive** `double` between 0 and 1.
+- `rnd_double(nanRate)` - generates a random **positive** `double` between 0 and
+  1 which will be `NaN` at a frequency defined by `nanRate`.
 
-### Arguments
+**Arguments:**
 
 - `nanRate` is an `int` defining the frequency of occurrence of `NaN` values:
 - `0`: No `NaN` will be returned.
 - `1`: Will only return `NaN`.
 - `N > 1`: On average, one in N generated values will be `NaN`.
 
-### Description
-
-- `rnd_double()` - generates a random **positive** `double` between 0 and 1.
-- `rnd_double(nanRate)` - generates a random **positive** `double` between 0 and
-  1 which will be `NaN` at a frequency defined by `nanRate`.
-
-### Return value
+**Return value:**
 
 Return value type is `double`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random double"
 SELECT rnd_double() FROM long_sequence(5);
@@ -352,9 +308,13 @@ SELECT rnd_double(2) FROM long_sequence(5);
 
 ## rnd_date()
 
-- `rnd_date(start, end, nanRate)` - generates a random date.
+- `rnd_date()` generates a random date between `start` and `end` dates (both
+  inclusive). IT will also generate `NaN` values at a frequency defined by
+  `nanRate`. When `start` or `end` are invalid dates, or when `start` is
+  superior to `end`, it will return `invalid range` error. When `nanRate` is
+  inferior to 0, it will return `invalid NAN rate` error.
 
-### Arguments
+**Arguments:**
 
 - `start` is a `date` defining the minimum possible generated date (inclusive)
 - `end` is a `date` defining the maximum possible generated date (inclusive)
@@ -363,19 +323,11 @@ SELECT rnd_double(2) FROM long_sequence(5);
   - `1`: Will only return `NaN`.
   - `N > 1`: On average, one in N generated values will be NaN.
 
-### Description
-
-- `rnd_date()` generates a random date between `start` and `end` dates (both
-  inclusive). IT will also generate `NaN` values at a frequency defined by
-  `nanRate`. When `start` or `end` are invalid dates, or when `start` is
-  superior to `end`, it will return `invalid range` error. When `nanRate` is
-  inferior to 0, it will return `invalid NAN rate` error.
-
-### Return value
+**Return value:**
 
 Return value type is `date`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random date"
 SELECT rnd_date(
@@ -393,9 +345,14 @@ FROM long_sequence(5);
 
 ## rnd_timestamp()
 
-- `rnd_timestamp(start, end, nanRate)` - generates a random timestamp.
+- `rnd_timestamp(start, end, nanRate)` generates a random timestamp between
+  `start` and `end` timestamps (both inclusive). It will also generate `NaN`
+  values at a frequency defined by `nanRate`. When `start` or `end` are invalid
+  timestamps, or when `start` is superior to `end`, it will return
+  `invalid range` error. When `nanRate` is inferior to 0, it will return
+  `invalid NAN rate` error.
 
-### Arguments
+**Arguments:**
 
 - `start` is a `timestamp` defining the minimum possible generated timestamp
   (inclusive)
@@ -406,20 +363,11 @@ FROM long_sequence(5);
   - `1`: Will only return `NaN`.
   - `N > 1`: On average, one in N generated values will be NaN.
 
-### Description
-
-- `rnd_timestamp(start, end, nanRate)` generates a random timestamp between
-  `start` and `end` timestamps (both inclusive). IT will also generate `NaN`
-  values at a frequency defined by `nanRate`. When `start` or `end` are invalid
-  timestamps, or when `start` is superior to `end`, it will return
-  `invalid range` error. When `nanRate` is inferior to 0, it will return
-  `invalid NAN rate` error.
-
-### Return value
+**Return value:**
 
 Return value type is `timestamp`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random timestamp"
 SELECT rnd_timestamp(
@@ -442,19 +390,15 @@ To generate increasing timestamps, please refer the page about
 
 ## rnd_char
 
-- `rnd_char()` generates a random printable character.
-
-### Description
-
 - `rnd_char()` is used to generate a random `char` which will be an uppercase
   character from the 26-letter A to Z alphabet. Letters from A to Z will be
   generated with equal probability.
 
-### Return value
+**Return value:**
 
 Return value type is `char`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random char"
 SELECT rnd_char() FROM long_sequence(5);
@@ -465,27 +409,6 @@ G, P, E, W, K
 ```
 
 ## rnd_symbol
-
-- `rnd_symbol(symbolList)` - chooses a `symbol` at random from a list.
-- `rnd_symbol(list_size, minLength, maxLength, nullRate)` - generates a random
-  `symbol`.
-
-### Arguments
-
-- `symbolList` is a variable-length list of possible `symbol` values expressed
-  as a comma-separated list of strings. For example,
-  `'a', 'bcd', 'efg123', '行'`
-- `list_size` is the number of distinct `symbol` values to generated
-- `minLength` is an `int` defining the minimum length for of a generated symbol
-  (inclusive)
-- `maxLength` is an `int` defining the maximum length for of a generated symbol
-  (inclusive)
-- `nullRate` is an `int` defining the frequency of occurrence of `null` values:
-  - `0`: No `null` will be returned.
-  - `1`: Will only return `null`.
-  - `N > 1`: On average, one in N generated values will be `null`.
-
-### Description
 
 - `rnd_symbol(symbolList)` is used to choose a random `symbol` from a list
   defined by the user. It is useful when looking to generate specific symbols
@@ -500,11 +423,26 @@ G, P, E, W, K
   `minLength` and `maxLength` (both inclusive). The function will also generate
   `null` values at a a rate defined by `nullRate`.
 
-### Return value
+**Arguments:**
+
+- `symbolList` is a variable-length list of possible `symbol` values expressed
+  as a comma-separated list of strings. For example,
+  `'a', 'bcd', 'efg123', '行'`
+- `list_size` is the number of distinct `symbol` values to generated
+- `minLength` is an `int` defining the minimum length for of a generated symbol
+  (inclusive)
+- `maxLength` is an `int` defining the maximum length for of a generated symbol
+  (inclusive)
+- `nullRate` is an `int` defining the frequency of occurrence of `null` values:
+  - `0`: No `null` will be returned.
+  - `1`: Will only return `null`.
+  - `N > 1`: On average, one in N generated values will be `null`.
+
+**Return value:**
 
 Return value type is `symbol`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random symbol from a list"
 SELECT rnd_symbol('ABC','def', '123')
@@ -526,11 +464,18 @@ FROM long_sequence(5);
 
 ## rnd_str
 
-- `rnd_str(stringList)` - chooses a `string` at random from a list.
-- `rnd_str(list_size, minLength, maxLength, nullRate)` - generates a random
-  `string`.
+- `rnd_str(stringList)` is used to choose a random `string` from a list defined
+  by the user. It is useful when looking to generate specific strings from a
+  finite list (e.g `BUY, SELL` or `AUTUMN, WINTER, SPRING, SUMMER`. Strings are
+  randomly chosen from the list with equal probability. When only one string is
+  provided in the list, this string will be chosen with 100% probability.
+- `rnd_str(count, minLength, maxLength, null)` generated a finite list of
+  distinct random string and chooses one string from the list at random. The
+  finite list is of size `list_size`. The generated strings length is between
+  `minLength` and `maxLength` (both inclusive). The function will also generate
+  `null` values at a a rate defined by `nullRate`.
 
-### Arguments
+**Arguments:**
 
 - `strList` is a variable-length list of possible `string` values expressed as a
   comma-separated list of strings. For example, `'a', 'bcd', 'efg123', '行'`
@@ -544,24 +489,11 @@ FROM long_sequence(5);
   - `1`: Will only return `null`.
   - `N > 1`: On average, one in N generated values will be `null`.
 
-### Description
-
-- `rnd_str(stringList)` is used to choose a random `string` from a list defined
-  by the user. It is useful when looking to generate specific strings from a
-  finite list (e.g `BUY, SELL` or `AUTUMN, WINTER, SPRING, SUMMER`. Strings are
-  randomly chosen from the list with equal probability. When only one string is
-  provided in the list, this string will be chosen with 100% probability.
-- `rnd_str(count, minLength, maxLength, null)` generated a finite list of
-  distinct random string and chooses one string from the list at random. The
-  finite list is of size `list_size`. The generated strings length is between
-  `minLength` and `maxLength` (both inclusive). The function will also generate
-  `null` values at a a rate defined by `nullRate`.
-
-### Return value
+**Return value:**
 
 Return value type is `string`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random string from a list"
 SELECT rnd_str('ABC','def', '123')
@@ -583,11 +515,12 @@ FROM long_sequence(8);
 
 ## rnd_bin
 
-- `rnd_bin()` generates random binary data.
-- `rnd_bin(minBytes, maxBytes, nullRate)` generates random binary data of a
-  custom-set size.
+- `rnd_bin()` generates random binary data of a size up to `32` bytes.
+- `rnd_bin(minBytes, maxBytes, nullRate)` generates random binary data of a size
+  between `minBytes` and `maxBytes` and returns `null` at a rate defined by
+  `nullRate`.
 
-### Arguments
+**Arguments:**
 
 - `minBytes` is a `long` defining the minimum size in bytes for of a generated
   binary (inclusive)
@@ -598,18 +531,11 @@ FROM long_sequence(8);
   - `1`: Will only return `null`.
   - `N > 1`: On average, one in N generated values will be `null`.
 
-### Description
-
-- `rnd_bin()` generates random binary data of a size up to `32` bytes.
-- `rnd_bin(minBytes, maxBytes, nullRate)` generates random binary data of a size
-  between `minBytes` and `maxBytes` and returns `null` at a rate defined by
-  `nullRate`.
-
-### Return value
+**Return value:**
 
 Return value type is `binary`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Random binary"
 SELECT rnd_bin() FROM long_sequence(5);

--- a/docs/reference/function/row-generator.md
+++ b/docs/reference/function/row-generator.md
@@ -9,14 +9,12 @@ description: Row generator function reference documentation.
 - `long_sequence(iterations)` - generates rows
 - `long_sequence(iterations, seed1, seed2)` - generates rows deterministically
 
-### Arguments
+**Arguments:**
 
 -`iterations`: is a `long` representing the number of rows to generate. -`seed1`
 and `seed2` are `long64` representing both parts of a `long128` seed.
 
-### Description
-
-#### Row generation
+### Row generation
 
 `long_sequence(iterations)` is used to:
 
@@ -31,7 +29,7 @@ of rows or more if your disk allows.
 
 :::
 
-#### Random number seed
+### Random number seed
 
 When `long_sequence` is used conjointly with
 [random generators](/docs/reference/function/random-value-generator/), these
@@ -47,7 +45,7 @@ all random functions.
 
 :::
 
-### Examples
+## Examples
 
 ```questdb-sql title="Generating multiple rows"
 SELECT x, rnd_double()

--- a/docs/reference/function/row-generator.md
+++ b/docs/reference/function/row-generator.md
@@ -45,7 +45,7 @@ all random functions.
 
 :::
 
-## Examples
+**Examples:**
 
 ```questdb-sql title="Generating multiple rows"
 SELECT x, rnd_double()

--- a/docs/reference/function/timestamp-generator.md
+++ b/docs/reference/function/timestamp-generator.md
@@ -6,30 +6,28 @@ description: Timestamp generator function reference documentation.
 
 ## timestamp_sequence
 
-- `timestamp_sequence(startTimestamp, step)` - generates increasing timestamps.
+- `timestamp_sequence(startTimestamp, step)` generates a sequence of `timestamp`
+  starting at `startTimestamp`, and incrementing by a `step` set as a `long`
+  value in microseconds. This `step` can be either;
 
-### Arguments
+  - a static value, in which case the growth will be monotonic, or
+
+  - a randomized value, in which case the growth will be randomized. This is
+    done using
+    [random value generator functions](/docs/reference/function/random-value-generator/).
+
+**Arguments:**
 
 - `startTimestamp`: is a `timestamp` representing the starting (i.e lowest)
   generated timestamp in the sequence.
 - `step`: is a `long` representing the interval between 2 consecutive generated
   timestamps in `microseconds`.
 
-### Description
-
-- `timestamp_sequence(startTimestamp, step)` generates a sequence of `timestamp`
-  starting at `startTimestamp`, and incrementing by a `step` set as a `long`
-  value in microseconds. This `step` can be.
-- a static value, in which case the growth will be monotonic.
-- a randomized value, in which case the growth will be randomized. This is done
-  using
-  [random value generator functions](/docs/reference/function/random-value-generator/).
-
-### Return value
+**Return value:**
 
 Return value type is `timestamp`.
 
-### Examples
+**Examples:**
 
 ```questdb-sql title="Monotonic timestamp increase"
 SELECT x, timestamp_sequence(


### PR DESCRIPTION
__Description:__
* Removed `Description` sections in favor of including this in the top-level description of a function to reduce redundant information
* Replaced section headings with bold text for:
  * Examples
  * Arguments
  * Return Values