### PR TITLE
docs: reword timestamp types in examples for consistency

### DIFF
--- a/docs/reference/sql/case.md
+++ b/docs/reference/sql/case.md
@@ -20,7 +20,7 @@ syntax. The user can define a return value when no condition is met using
 
 Assume the following data
 
-| Name  | Age |
+| name  | age |
 | ----- | --- |
 | Tom   | 4   |
 | Jerry | 19  |
@@ -29,7 +29,7 @@ Assume the following data
 
 ```questdb-sql title="CASE with ELSE"
 select
-Name,
+name,
 case
     when age > 18 then 'major'
     else 'minor'
@@ -39,7 +39,7 @@ from table
 
 Result
 
-| Name  | case  |
+| name  | case  |
 | ----- | ----- |
 | Tom   | minor |
 | Jerry | major |
@@ -57,7 +57,7 @@ from table
 
 Result
 
-| Name  | case  |
+| name  | case  |
 | ----- | ----- |
 | Tom   | null  |
 | Jerry | major |

--- a/docs/reference/sql/cast.md
+++ b/docs/reference/sql/cast.md
@@ -104,9 +104,9 @@ to_timestamp('2019-10-17T00:00:00', 'yyyy-MM-ddTHH:mm:ss') + 323,
 to_timestamp('2019-10-17T00:00:00', 'yyyy-MM-ddTHH:mm:ss') + 0.323;
 ```
 
-| cast | cast1    | cast2                       | cast3            |
-| ---- | -------- | --------------------------- | ---------------- |
-| 1801 | 1234.567 | 2019-10-17T00:00:00.000323Z | 1571270400000000 |
+| column | column1  | column2                     | column3          |
+| ------ | -------- | --------------------------- | ---------------- |
+| 1801   | 1234.567 | 2019-10-17T00:00:00.000323Z | 1571270400000000 |
 
 When inserting into a table, QuestDB will cast data implicitly to match the type
 of the destination column.
@@ -117,7 +117,7 @@ CREATE TABLE my_table(my_number long);
 
 -- We then insert a value into this table. Note that the value is of timestamp type
 -- but that we are trying to insert into a long type column:
-INSERT INTO my_table values((to_timestamp('2019-10-17T00:00:00', 'yyyy-MM-ddTHH:mm:ss'));
+INSERT INTO my_table values((to_timestamp('2019-10-17T00:00:00', 'yyyy-MM-ddTHH:mm:ss')));
 
 -- As timestamp can be converted to long without loss, QuestDB performs an implicit
 -- cast on the value before inserting it. Therefore the value is now stored as a long:

--- a/docs/reference/sql/fill.md
+++ b/docs/reference/sql/fill.md
@@ -22,54 +22,54 @@ options are applied to aggregates based on order of appearance in the query.
 | `NULL`     | Fills with `NULL`                                                                                                                                  |
 | `PREV`     | Fills using the previous value                                                                                                                     |
 | `LINEAR`   | Fills by linear interpolation of the 2 surrounding points                                                                                          |
-| `x`        | Fills with a constant value - where `x` is the desired value, for example `FILL(100.05)`                                                  |
+| `x`        | Fills with a constant value - where `x` is the desired value, for example `FILL(100.05)`                                                           |
 
 ## Examples
 
 Consider an example table named `prices`:
 
-| timestamp | price |
-| --------- | ----- |
-| ts1       | p1    |
-| ts2       | p2    |
-| ts3       | p3    |
-| ...       | ...   |
-| tsn       | pn    |
+| ts  | price |
+| --- | ----- |
+| 2021-01-01T12:00:00.000000Z | p1    |
+| 2021-01-01T13:00:00.000000Z | p2    |
+| 2021-01-01T14:00:00.000000Z | p3    |
+| ... | ...   |
+| tsn | pn    |
 
 The following query returns the minimum, maximum and average price per hour:
 
 ```questdb-sql
-SELECT timestamp, min(price) min, max(price) max, avg(price) avg
+SELECT ts, min(price) min, max(price) max, avg(price) avg
 FROM PRICES
 SAMPLE BY 1h;
 ```
 
 The returned results look like this:
 
-| timestamp | min  | max  | average |
-| --------- | ---- | ---- | ------- |
-| ts1       | min1 | max1 | avg1    |
-| ...       | ...  | ...  | ...     |
-| tsn       | minn | maxn | avgn    |
+| ts  | min  | max  | average |
+| --- | ---- | ---- | ------- |
+| 2021-01-01T12:00:00.000000Z | min1 | max1 | avg1    |
+| ... | ...  | ...  | ...     |
+| tsn | minn | maxn | avgn    |
 
 In the below example, there is no `price` data during the entire third hour. As
 there are missing values, an average aggregate cannot be calculated for this
-hour at `ts3`:
+hour at `2021-01-01T14:00:00.000000Z`:
 
-| timestamp | min    | max    | average |
-| --------- | ------ | ------ | ------- |
-| ts1       | min1   | max1   | avg1    |
-| ts2       | min2   | max2   | avg2    |
-| `ts3`     | `null` | `null` | `null`  |
-| ts4       | min4   | max4   | avg4    |
-| ...       | ...    | ...    | ...     |
-| tsn       | minn   | maxn   | avgn    |
+| ts    | min    | max    | average |
+| ----- | ------ | ------ | ------- |
+| 2021-01-01T12:00:00.000000Z   | min1   | max1   | avg1    |
+| 2021-01-01T13:00:00.000000Z   | min2   | max2   | avg2    |
+| 2021-01-01T14:00:00.000000Z | `null` | `null` | `null`  |
+| 2021-01-01T15:00:00.000000Z   | min4   | max4   | avg4    |
+| ...   | ...    | ...    | ...     |
+| tsn   | minn   | maxn   | avgn    |
 
 Based on this example, the following `FILL` strategies can be employed,
 demonstrating filling with `NULL`, a constant value, and the previous value:
 
 ```questdb-sql title="Using three fillOptions for filling missing data"
-SELECT timestamp, min(price) min, max(price) max, avg(price) avg
+SELECT ts, min(price) min, max(price) max, avg(price) avg
 FROM PRICES
 SAMPLE BY 1h
 FILL(NULL, 0, PREV);
@@ -77,20 +77,20 @@ FILL(NULL, 0, PREV);
 
 This query returns the following results:
 
-| timestamp | min    | max  | average |
-| --------- | ------ | ---- | ------- |
-| ts1       | min1   | max1 | avg1    |
-| ts2       | min2   | max2 | avg2    |
-| `ts3`     | `null` | `0`  | `avg2`  |
-| ts4       | min4   | max4 | avg4    |
-| ...       | ...    | ...  | ...     |
-| tsn       | minn   | maxn | avgn    |
+| ts    | min    | max  | average |
+| ----- | ------ | ---- | ------- |
+| 2021-01-01T12:00:00.000000Z   | min1   | max1 | avg1    |
+| 2021-01-01T13:00:00.000000Z   | min2   | max2 | avg2    |
+| `2021-01-01T14:00:00.000000Z` | `null` | `0`  | `avg2`  |
+| 2021-01-01T15:00:00.000000Z   | min4   | max4 | avg4    |
+| ...   | ...    | ...  | ...     |
+| tsn   | minn   | maxn | avgn    |
 
 This query demonstrates the remaining `fillOptions` using a constant value and
 linear interpolation:
 
 ```questdb-sql
-SELECT timestamp, min(price) min, avg(price) avg
+SELECT ts, min(price) min, avg(price) avg
 FROM PRICES
 SAMPLE BY 1h
 FILL(25.5, LINEAR);
@@ -98,11 +98,11 @@ FILL(25.5, LINEAR);
 
 The results of this query look like the following:
 
-| timestamp | min    | average         |
-| --------- | ------ | --------------- |
-| ts1       | min1   | avg1            |
-| ts2       | min2   | avg2            |
-| `ts3`     | `25.5` | `(avg2+avg4)/2` |
-| ts4       | min4   | avg4            |
-| ...       | ...    | ...             |
-| tsn       | minn   | avgn            |
+| ts    | min    | average         |
+| ----- | ------ | --------------- |
+| 2021-01-01T12:00:00.000000Z   | min1   | avg1            |
+| 2021-01-01T13:00:00.000000Z   | min2   | avg2            |
+| `2021-01-01T14:00:00.000000Z` | `25.5` | `(avg2+avg4)/2` |
+| 2021-01-01T15:00:00.000000Z   | min4   | avg4            |
+| ...   | ...    | ...             |
+| tsn   | minn   | avgn            |

--- a/docs/reference/sql/fill.md
+++ b/docs/reference/sql/fill.md
@@ -28,13 +28,13 @@ options are applied to aggregates based on order of appearance in the query.
 
 Consider an example table named `prices`:
 
-| ts  | price |
-| --- | ----- |
+| ts                          | price |
+| --------------------------- | ----- |
 | 2021-01-01T12:00:00.000000Z | p1    |
 | 2021-01-01T13:00:00.000000Z | p2    |
 | 2021-01-01T14:00:00.000000Z | p3    |
-| ... | ...   |
-| tsn | pn    |
+| ...                         | ...   |
+| tsn                         | pn    |
 
 The following query returns the minimum, maximum and average price per hour:
 
@@ -46,24 +46,24 @@ SAMPLE BY 1h;
 
 The returned results look like this:
 
-| ts  | min  | max  | average |
-| --- | ---- | ---- | ------- |
+| ts                          | min  | max  | average |
+| --------------------------- | ---- | ---- | ------- |
 | 2021-01-01T12:00:00.000000Z | min1 | max1 | avg1    |
-| ... | ...  | ...  | ...     |
-| tsn | minn | maxn | avgn    |
+| ...                         | ...  | ...  | ...     |
+| tsn                         | minn | maxn | avgn    |
 
 In the below example, there is no `price` data during the entire third hour. As
 there are missing values, an average aggregate cannot be calculated for this
 hour at `2021-01-01T14:00:00.000000Z`:
 
-| ts    | min    | max    | average |
-| ----- | ------ | ------ | ------- |
-| 2021-01-01T12:00:00.000000Z   | min1   | max1   | avg1    |
-| 2021-01-01T13:00:00.000000Z   | min2   | max2   | avg2    |
+| ts                          | min    | max    | average |
+| --------------------------- | ------ | ------ | ------- |
+| 2021-01-01T12:00:00.000000Z | min1   | max1   | avg1    |
+| 2021-01-01T13:00:00.000000Z | min2   | max2   | avg2    |
 | 2021-01-01T14:00:00.000000Z | `null` | `null` | `null`  |
-| 2021-01-01T15:00:00.000000Z   | min4   | max4   | avg4    |
-| ...   | ...    | ...    | ...     |
-| tsn   | minn   | maxn   | avgn    |
+| 2021-01-01T15:00:00.000000Z | min4   | max4   | avg4    |
+| ...                         | ...    | ...    | ...     |
+| tsn                         | minn   | maxn   | avgn    |
 
 Based on this example, the following `FILL` strategies can be employed,
 demonstrating filling with `NULL`, a constant value, and the previous value:
@@ -77,14 +77,14 @@ FILL(NULL, 0, PREV);
 
 This query returns the following results:
 
-| ts    | min    | max  | average |
-| ----- | ------ | ---- | ------- |
+| ts                            | min    | max  | average |
+| ----------------------------- | ------ | ---- | ------- |
 | 2021-01-01T12:00:00.000000Z   | min1   | max1 | avg1    |
 | 2021-01-01T13:00:00.000000Z   | min2   | max2 | avg2    |
 | `2021-01-01T14:00:00.000000Z` | `null` | `0`  | `avg2`  |
 | 2021-01-01T15:00:00.000000Z   | min4   | max4 | avg4    |
-| ...   | ...    | ...  | ...     |
-| tsn   | minn   | maxn | avgn    |
+| ...                           | ...    | ...  | ...     |
+| tsn                           | minn   | maxn | avgn    |
 
 This query demonstrates the remaining `fillOptions` using a constant value and
 linear interpolation:
@@ -98,11 +98,11 @@ FILL(25.5, LINEAR);
 
 The results of this query look like the following:
 
-| ts    | min    | average         |
-| ----- | ------ | --------------- |
+| ts                            | min    | average         |
+| ----------------------------- | ------ | --------------- |
 | 2021-01-01T12:00:00.000000Z   | min1   | avg1            |
 | 2021-01-01T13:00:00.000000Z   | min2   | avg2            |
 | `2021-01-01T14:00:00.000000Z` | `25.5` | `(avg2+avg4)/2` |
 | 2021-01-01T15:00:00.000000Z   | min4   | avg4            |
-| ...   | ...    | ...             |
-| tsn   | minn   | avgn            |
+| ...                           | ...    | ...             |
+| tsn                           | minn   | avgn            |

--- a/docs/reference/sql/latest-by.md
+++ b/docs/reference/sql/latest-by.md
@@ -63,7 +63,7 @@ LATEST BY cust_id, balance_ccy;
 The below queries illustrate how to change the execution order in a query by
 using brackets. Assume the following table
 
-| cust_id | balance_ccy | balance | inactive | timestamp                   |
+| cust_id | balance_ccy | balance | inactive | ts                   |
 | ------- | ----------- | ------- | -------- | --------------------------- |
 | 1       | USD         | 1500    | FALSE    | 2020-04-22T16:11:22.704665Z |
 | 1       | EUR         | 650.5   | FALSE    | 2020-04-22T16:11:32.904234Z |
@@ -88,7 +88,7 @@ Since the latest USD balance for customer 1 is equal to 330.5, it is filtered
 out in the first step. Therefore, the returned balance is 1500, which is the
 latest possible balance above 800.
 
-| cust_id | balance_ccy | balance | inactive | timestamp                   |
+| cust_id | balance_ccy | balance | inactive | ts                   |
 | ------- | ----------- | ------- | -------- | --------------------------- |
 | 1       | USD         | 1500    | FALSE    | 2020-04-22T16:11:22.704665Z |
 | 2       | USD         | 900.75  | FALSE    | 2020-04-22T16:12:43.504432Z |
@@ -108,7 +108,7 @@ then filters out those below 800. The steps are
 - Filter out balances below 800. Since the latest balance for customer 1 is
   equal to 330.5, it is filtered out in the second step.
 
-| cust_id | balance_ccy | balance | inactive | timestamp                   |
+| cust_id | balance_ccy | balance | inactive | ts                   |
 | ------- | ----------- | ------- | -------- | --------------------------- |
 | 2       | USD         | 900.75  | FALSE    | 2020-04-22T16:12:43.504432Z |
 | 2       | EUR         | 880.2   | FALSE    | 2020-04-22T16:18:34.404665Z |

--- a/docs/reference/sql/latest-by.md
+++ b/docs/reference/sql/latest-by.md
@@ -63,7 +63,7 @@ LATEST BY cust_id, balance_ccy;
 The below queries illustrate how to change the execution order in a query by
 using brackets. Assume the following table
 
-| cust_id | balance_ccy | balance | inactive | ts                   |
+| cust_id | balance_ccy | balance | inactive | ts                          |
 | ------- | ----------- | ------- | -------- | --------------------------- |
 | 1       | USD         | 1500    | FALSE    | 2020-04-22T16:11:22.704665Z |
 | 1       | EUR         | 650.5   | FALSE    | 2020-04-22T16:11:32.904234Z |
@@ -88,7 +88,7 @@ Since the latest USD balance for customer 1 is equal to 330.5, it is filtered
 out in the first step. Therefore, the returned balance is 1500, which is the
 latest possible balance above 800.
 
-| cust_id | balance_ccy | balance | inactive | ts                   |
+| cust_id | balance_ccy | balance | inactive | ts                          |
 | ------- | ----------- | ------- | -------- | --------------------------- |
 | 1       | USD         | 1500    | FALSE    | 2020-04-22T16:11:22.704665Z |
 | 2       | USD         | 900.75  | FALSE    | 2020-04-22T16:12:43.504432Z |
@@ -108,7 +108,7 @@ then filters out those below 800. The steps are
 - Filter out balances below 800. Since the latest balance for customer 1 is
   equal to 330.5, it is filtered out in the second step.
 
-| cust_id | balance_ccy | balance | inactive | ts                   |
+| cust_id | balance_ccy | balance | inactive | ts                          |
 | ------- | ----------- | ------- | -------- | --------------------------- |
 | 2       | USD         | 900.75  | FALSE    | 2020-04-22T16:12:43.504432Z |
 | 2       | EUR         | 880.2   | FALSE    | 2020-04-22T16:18:34.404665Z |

--- a/docs/reference/sql/sample-by.md
+++ b/docs/reference/sql/sample-by.md
@@ -8,8 +8,8 @@ description: SAMPLE BY SQL keyword reference documentation.
 aggregates of homogeneous time chunks as part of a
 [SELECT statement](/docs/reference/sql/select/).
 
-Users performing `SAMPLE BY` queries on datasets __with missing data__ may make use
-of the [FILL](/docs/reference/sql/fill/) keyword to specify a fill behavior.
+Users performing `SAMPLE BY` queries on datasets **with missing data** may make
+use of the [FILL](/docs/reference/sql/fill/) keyword to specify a fill behavior.
 
 :::note
 
@@ -29,13 +29,13 @@ results, and `n` is the number of time chunks that will be summarised together.
 
 Assume the following table
 
-| ts | buysell | quantity | price |
-| --------- | ------- | -------- | ----- |
-| ts1       | B       | q1       | p1    |
-| ts2       | S       | q2       | p2    |
-| ts3       | S       | q3       | p3    |
-| ...       | ...     | ...      | ...   |
-| tsn       | B       | qn       | pn    |
+| ts  | buysell | quantity | price |
+| --- | ------- | -------- | ----- |
+| ts1 | B       | q1       | p1    |
+| ts2 | S       | q2       | p2    |
+| ts3 | S       | q3       | p3    |
+| ... | ...     | ...      | ...   |
+| tsn | B       | qn       | pn    |
 
 The following will return the number of trades per hour:
 

--- a/docs/reference/sql/sample-by.md
+++ b/docs/reference/sql/sample-by.md
@@ -29,7 +29,7 @@ results, and `n` is the number of time chunks that will be summarised together.
 
 Assume the following table
 
-| timestamp | buysell | quantity | price |
+| ts | buysell | quantity | price |
 | --------- | ------- | -------- | ----- |
 | ts1       | B       | q1       | p1    |
 | ts2       | S       | q2       | p2    |
@@ -40,7 +40,7 @@ Assume the following table
 The following will return the number of trades per hour:
 
 ```questdb-sql title="trades - hourly interval"
-SELECT timestamp, count()
+SELECT ts, count()
 FROM TRADES
 SAMPLE BY 1h;
 ```
@@ -48,7 +48,7 @@ SAMPLE BY 1h;
 The following will return the trade volume in 30 minute intervals
 
 ```questdb-sql title="trades - 30 minute interval"
-SELECT timestamp, sum(quantity*price)
+SELECT ts, sum(quantity*price)
 FROM TRADES
 SAMPLE BY 30m;
 ```
@@ -57,7 +57,7 @@ The following will return the average trade notional (where notional is = q \*
 p) by day:
 
 ```questdb-sql title="trades - daily interval"
-SELECT timestamp, avg(quantity*price)
+SELECT ts, avg(quantity*price)
 FROM TRADES
 SAMPLE BY 1d;
 ```

--- a/docs/reference/sql/where.md
+++ b/docs/reference/sql/where.md
@@ -222,7 +222,7 @@ designated timestamp can be applied
 SELECT scores WHERE ts = '2010-01-12T00:02:26.000Z';
 ```
 
-| timestamp                | score |
+| ts               | score |
 | ------------------------ | ----- |
 | 2010-01-12T00:02:26.000Z | 2.4   |
 | 2010-01-12T00:02:26.000Z | 3.1   |
@@ -232,7 +232,7 @@ SELECT scores WHERE ts = '2010-01-12T00:02:26.000Z';
 SELECT scores WHERE ts = '2010-01-12T00:02:26.000000Z';
 ```
 
-| timestamp                   | score |
+| ts                  | score |
 | --------------------------- | ----- |
 | 2010-01-12T00:02:26.000000Z | 2.4   |
 | 2010-01-12T00:02:26.000000Z | 3.1   |
@@ -250,7 +250,7 @@ Return results within a defined range
 SELECT * FROM scores WHERE ts = '2018';
 ```
 
-| timestamp                   | score |
+| ts                  | score |
 | --------------------------- | ----- |
 | 2018-01-01T00:0000.000000Z  | 123.4 |
 | ...                         | ...   |
@@ -260,7 +260,7 @@ SELECT * FROM scores WHERE ts = '2018';
 SELECT * FROM scores WHERE ts = '2018-05-23T12:15';
 ```
 
-| timestamp                   | score |
+| ts                  | score |
 | --------------------------- | ----- |
 | 2018-05-23T12:15:00.000000Z | 123.4 |
 | ...                         | ...   |
@@ -288,7 +288,7 @@ SELECT * FROM scores WHERE ts = '2018;1M';
 The range is 2018. The modifier extends the upper bound (originally 31 Dec 2018)
 by one month.
 
-| timestamp                   | score |
+| ts                  | score |
 | --------------------------- | ----- |
 | 2018-01-01T00:00:00.000000Z | 123.4 |
 | ...                         | ...   |
@@ -301,7 +301,7 @@ SELECT * FROM scores WHERE ts = '2018-01;-3d';
 The range is Jan 2018. The modifier reduces the upper bound (originally 31
 Dec 2018) by 3 days.
 
-| timestamp                   | score |
+| ts                  | score |
 | --------------------------- | ----- |
 | 2018-01-01T00:00:00.000000Z | 123.4 |
 | ...                         | ...   |
@@ -324,7 +324,7 @@ SELECT * FROM scores
 WHERE ts in('2018-01-01T00:00:23.000000Z' , '2018-01-01T00:00:23.500000Z');
 ```
 
-| timestamp                   | value |
+| ts                  | value |
 | --------------------------- | ----- |
 | 2018-01-01T00:00:23.000000Z | 123.4 |
 | ...                         | ...   |

--- a/docs/reference/sql/where.md
+++ b/docs/reference/sql/where.md
@@ -222,7 +222,7 @@ designated timestamp can be applied
 SELECT scores WHERE ts = '2010-01-12T00:02:26.000Z';
 ```
 
-| ts               | score |
+| ts                       | score |
 | ------------------------ | ----- |
 | 2010-01-12T00:02:26.000Z | 2.4   |
 | 2010-01-12T00:02:26.000Z | 3.1   |
@@ -232,7 +232,7 @@ SELECT scores WHERE ts = '2010-01-12T00:02:26.000Z';
 SELECT scores WHERE ts = '2010-01-12T00:02:26.000000Z';
 ```
 
-| ts                  | score |
+| ts                          | score |
 | --------------------------- | ----- |
 | 2010-01-12T00:02:26.000000Z | 2.4   |
 | 2010-01-12T00:02:26.000000Z | 3.1   |
@@ -250,7 +250,7 @@ Return results within a defined range
 SELECT * FROM scores WHERE ts = '2018';
 ```
 
-| ts                  | score |
+| ts                          | score |
 | --------------------------- | ----- |
 | 2018-01-01T00:0000.000000Z  | 123.4 |
 | ...                         | ...   |
@@ -260,7 +260,7 @@ SELECT * FROM scores WHERE ts = '2018';
 SELECT * FROM scores WHERE ts = '2018-05-23T12:15';
 ```
 
-| ts                  | score |
+| ts                          | score |
 | --------------------------- | ----- |
 | 2018-05-23T12:15:00.000000Z | 123.4 |
 | ...                         | ...   |
@@ -288,7 +288,7 @@ SELECT * FROM scores WHERE ts = '2018;1M';
 The range is 2018. The modifier extends the upper bound (originally 31 Dec 2018)
 by one month.
 
-| ts                  | score |
+| ts                          | score |
 | --------------------------- | ----- |
 | 2018-01-01T00:00:00.000000Z | 123.4 |
 | ...                         | ...   |
@@ -301,7 +301,7 @@ SELECT * FROM scores WHERE ts = '2018-01;-3d';
 The range is Jan 2018. The modifier reduces the upper bound (originally 31
 Dec 2018) by 3 days.
 
-| ts                  | score |
+| ts                          | score |
 | --------------------------- | ----- |
 | 2018-01-01T00:00:00.000000Z | 123.4 |
 | ...                         | ...   |
@@ -324,7 +324,7 @@ SELECT * FROM scores
 WHERE ts in('2018-01-01T00:00:23.000000Z' , '2018-01-01T00:00:23.500000Z');
 ```
 
-| ts                  | value |
+| ts                          | value |
 | --------------------------- | ----- |
 | 2018-01-01T00:00:23.000000Z | 123.4 |
 | ...                         | ...   |


### PR DESCRIPTION
__Description:__
* To reduce confusion with the use of **timestamp**, columns demonstrating timestamp type are named `ts`.
* Once-over for example uppercase/lowercase in SQL and illustrative tables