### PR TITLE
docs: direct use of double quotes for tables with special characters

### DIFF
--- a/docs/reference/sql/create-table.md
+++ b/docs/reference/sql/create-table.md
@@ -25,10 +25,11 @@ both ASCII and Unicode characters.
   exists with the requested name.
 
 - Table names containing spaces or period `.` character must be enclosed in
-  **single quotes**, for example:
+  **double quotes**, for example:
 
   ```questdb-sql
-  CREATE TABLE 'example out of.space' (a INT);
+  CREATE TABLE "example out of.space" (a INT);
+  INSERT INTO "example out of.space" values (1);
   ```
 
 :::


### PR DESCRIPTION
__Description:__
The docs mention create table with special characters (space and period) should be done using single quotes. This is possible, but inserts must be done using double quotes. For the sake of consistency, change to double quotes and add insert example