### PR TITLE
chore: add job specs to careers page

### DIFF
--- a/src/pages/careers.tsx
+++ b/src/pages/careers.tsx
@@ -120,8 +120,34 @@ const CareersPage = () => {
                 />
               </span>
             </a>
+            <a className={joCss.job} href="head-of-developer-relations/">
+              <h3 className={joCss.job__title}>Head of Developer Relations</h3>
+              <p className={joCss.job__location}>Remote</p>
+              <span className={joCss.job__cta}>
+                Details&nbsp;
+                <img
+                  alt="Right arrow"
+                  height={20}
+                  src="/img/pages/careers/arrowRight.svg"
+                  width={20}
+                />
+              </span>
+            </a>
             <a className={joCss.job} href="backend-software-engineer/">
               <h3 className={joCss.job__title}>Software Engineer, Backend</h3>
+              <p className={joCss.job__location}>Remote</p>
+              <span className={joCss.job__cta}>
+                Details&nbsp;
+                <img
+                  alt="Right arrow"
+                  height={20}
+                  src="/img/pages/careers/arrowRight.svg"
+                  width={20}
+                />
+              </span>
+            </a>
+            <a className={joCss.job} href="front-end-engineer/">
+              <h3 className={joCss.job__title}>Software Engineer, Frontend</h3>
               <p className={joCss.job__location}>Remote</p>
               <span className={joCss.job__cta}>
                 Details&nbsp;


### PR DESCRIPTION
__Additions:__
The following two careers pages are now listed in "open positions" section

* Front end engineer
* Head of dev rel