### PR TITLE
chore: update quote size in enterprise cards

### DIFF
--- a/src/assets/quotes.ts
+++ b/src/assets/quotes.ts
@@ -52,7 +52,7 @@ const quotes: Quote[] = [
     text:
       "With QuestDB's turnkey solution in Docker, we quickly built a solid foundation for a data acquisition pipeline with billions of measurements.",
     author: "Andreas Landmann",
-    role: "Director of Research and Technology",
+    role: "Director, Research & Technology",
     company: "DATRON",
   },
   {

--- a/src/css/enterprise/quote.module.css
+++ b/src/css/enterprise/quote.module.css
@@ -70,7 +70,7 @@
 .quote__author {
   --ifm-paragraph-margin-bottom: 0;
   color: var(--palette-pale-blue);
-  font-size: var(--font-size-large);
+  font-size: var(--font-size-small);
 }
 
 .controls {


### PR DESCRIPTION
__Description:__
The quotes should fit on a single line if possible, these changes make the author text slightly smaller to allow them to fit on one line in most screen sizes.