### PR TITLE
chore: Add dev rel engineer

### DIFF
--- a/src/pages/careers.tsx
+++ b/src/pages/careers.tsx
@@ -120,8 +120,8 @@ const CareersPage = () => {
                 />
               </span>
             </a>
-            <a className={joCss.job} href="head-of-developer-relations/">
-              <h3 className={joCss.job__title}>Head of Developer Relations</h3>
+            <a className={joCss.job} href="developer-relations-engineer/">
+              <h3 className={joCss.job__title}>Developer Relations Engineer</h3>
               <p className={joCss.job__location}>Remote</p>
               <span className={joCss.job__cta}>
                 Details&nbsp;

--- a/src/pages/careers/developer-relations-engineer.mdx
+++ b/src/pages/careers/developer-relations-engineer.mdx
@@ -1,5 +1,5 @@
 ---
-title: Head of Developer Relations | Careers at QuestDB
+title: Developer Relations Engineer | Careers at QuestDB
 wrapperClassName: career
 ---
 
@@ -25,9 +25,12 @@ Helping developers solve their problems is at the center of what we do. Your
 role will consist of engaging with the user base and orchestrating the growth of
 our open source communities.
 
+We are looking for an individual who is passionate about data, driven to spur continuous awareness 
+of a very technical product and enjoys interacting with community members on a daily basis. 
+
 This is an open-ended role with a substantial degree of autonomy. You will have
-full liberty to develop outreach channels such as promoting content to spur
-adoption, planning events, marketing, PR and social media initiatives, as well
+full liberty to develop outreach channels and partnerships to spur
+adoption, planning events, webinars, podcasts, marketing, social media initiatives, as well
 as any additional direction you will deem relevant.
 
 <h2>Responsibilities</h2>
@@ -39,21 +42,24 @@ as any additional direction you will deem relevant.
   and grow our Slack community. Manage outreach to developers online moderating
   day-to-day community activity in the discussion forums and via conferences,
   webinars, events, workshops, etc
-- Create content: Work with the entire team to create technical articles and
-  blog posts for developers
-- Identify strategic partnership opportunities to grow our developer community
+- Work in tandem with our content team to create technical articles, tutorials and
+  youtube content for developers
+- Identify strategic partnership opportunities to grow awareness
+- Build and deliver technical training workshops using QuestDB and other tools in the
+  open source ecosystem
+
 
 <h2>Requirements</h2>
 
 - 3+ years of experience in community development
 - Passionate about open source and the developer community
-- Time-series database knowledge preferred
+- Time-series database and SQL knowledge preferred
 - Strong writing and communication skills
-- Marketing experience is a plus
 - Relationships in prominent Open Source communities is a plus
 - Familiarity with cloud native technologies and observability tools
 - Excellent spoken and written English
-- Analytical mindset
+- Background as software developer is a plus
+- Entrepreneurial mindset is a plus 
 
 <h2>Working at QuestDB</h2>
 
@@ -68,4 +74,4 @@ technology to power the infrastructure of tomorrow.
 - Our team is ambitious and tackles the most difficult problems at the deepest
   data infrastructure layer.
 
-<CareerEmailUs title="Head of Developer Relations" />
+<CareerEmailUs title="Developer Relations Engineer" />

--- a/src/pages/careers/head-of-developer-relations.mdx
+++ b/src/pages/careers/head-of-developer-relations.mdx
@@ -49,11 +49,11 @@ as any additional direction you will deem relevant.
 - Passionate about open source and the developer community
 - Time-series database knowledge preferred
 - Strong writing and communication skills
-- Familiarity with cloud native technologies and observability tools
+- Familiarity with cloud-native technologies and observability tools
 - Excellent spoken and written English
 - Analytical mindset
 - Marketing experience is a plus
-- Relationships in prominent Open Source communities is a plus
+- Relationships in prominent open source communities is a plus
 
 <h2>Working at QuestDB</h2>
 

--- a/src/pages/careers/head-of-developer-relations.mdx
+++ b/src/pages/careers/head-of-developer-relations.mdx
@@ -1,11 +1,11 @@
 ---
-title: Developer Relations Engineer | Careers at QuestDB
+title: Head of Developer Relations | Careers at QuestDB
 wrapperClassName: career
 ---
 
 import CareerEmailUs from "@theme/CareerEmailUs"
 
-<h1>Developer Relations Engineer</h1>
+<h1>Head of Developer Relations</h1>
 
 <h2> About QuestDB</h2>
 
@@ -19,47 +19,41 @@ financial services, IoT, application monitoring, and machine learning.
 We are a remote-first company based in London and backed by leading venture
 capital firms and Y Combinator.
 
-<h2>The role</h2>
+<h2>The Role</h2>
 
 Helping developers solve their problems is at the center of what we do. Your
 role will consist of engaging with the user base and orchestrating the growth of
 our open source communities.
 
-We are looking for an individual who is passionate about data, driven to spur
-continuous awareness of a deep technology product and enjoys interacting with
-community members on a daily basis.
-
 This is an open-ended role with a substantial degree of autonomy. You will have
-full liberty to develop outreach channels and partnerships to spur adoption,
-planning events, webinars, podcasts, marketing, social media initiatives, as
-well as any additional direction that you deem relevant.
+full liberty to develop outreach channels such as promoting content to spur
+adoption, planning events, marketing, PR and social media initiatives, as well
+as any additional direction you will deem relevant.
 
 <h2>Responsibilities</h2>
 
-- Understand and adapt to developers needs: Create feedback loops with the
+- Understand and track developers needs: Create feedback loops with the
   developer community to inform product roadmap. Be the first point of contact
   for developers requests and questions
 - Manage and engage the community: Build engagement developers' social channels
   and grow our Slack community. Manage outreach to developers online moderating
   day-to-day community activity in the discussion forums and via conferences,
   webinars, events, workshops, etc
-- Work in tandem with our content team to create technical articles, tutorials
-  and YouTube content for developers
-- Identify strategic partnership opportunities to grow awareness
-- Build and deliver technical training workshops using QuestDB and other tools
-  in the open source ecosystem
+- Create content: Work with the entire team to create technical articles and
+  blog posts for developers
+- Identify strategic partnership opportunities to grow our developer community
 
 <h2>Requirements</h2>
 
 - 3+ years of experience in community development
 - Passionate about open source and the developer community
-- Time-series database and SQL knowledge preferred
+- Time-series database knowledge preferred
 - Strong writing and communication skills
-- Familiarity with cloud-native technologies and observability tools
+- Familiarity with cloud native technologies and observability tools
 - Excellent spoken and written English
-- Background as software developer is a plus
-- Relationships in prominent open source communities is a plus
-- Entrepreneurial mindset is a plus
+- Analytical mindset
+- Marketing experience is a plus
+- Relationships in prominent Open Source communities is a plus
 
 <h2>Working at QuestDB</h2>
 
@@ -74,4 +68,4 @@ technology to power the infrastructure of tomorrow.
 - Our team is ambitious and tackles the most difficult problems at the deepest
   data infrastructure layer.
 
-<CareerEmailUs title="Developer Relations Engineer" />
+<CareerEmailUs title="Head of Developer Relations" />

--- a/src/theme/CareerEmailUs/index.tsx
+++ b/src/theme/CareerEmailUs/index.tsx
@@ -16,7 +16,10 @@ const CareerEmailUs = ({ title }: Props) => {
         relevant links to your portfolio (LinkedIn, GitHub, personal website,
         etc.) and a few words about why you are interested in QuestDB.
       </p>
-      <a className={styles.link} href="mailto:careers@questdb.io">
+      <a
+        className={styles.link}
+        href={"mailto:careers@questdb.io?subject=" + title}
+      >
         careers@questdb.io
       </a>
     </section>


### PR DESCRIPTION
__Description:__
* Adding dev rel engineer
* Highlighting dev rel engineer instead of __head of dev rel__ on careers page
* Pre-fill `mailto` subject line with role title