### PR TITLE
chore: bump sv number for 6.0.0

### DIFF
--- a/docs/reference/api/java-embedded.md
+++ b/docs/reference/api/java-embedded.md
@@ -18,10 +18,19 @@ import TabItem from "@theme/TabItem"
 
 <TabItem value="maven">
 
-```xml
+
+```xml title="JDK11"
 <dependency>
     <groupId>org.questdb</groupId>
     <artifactId>questdb</artifactId>
+    <version>{@version@}</version>
+</dependency>
+```
+
+```xml title="JDK8"
+<dependency>
+    <groupId>org.questdb</groupId>
+    <artifactId>questdb-jdk8</artifactId>
     <version>{@version@}</version>
 </dependency>
 ```

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,7 +21,7 @@ const customFields = {
   slackUrl: `https://slack.${domain}`,
   stackoverflowUrl: "https://stackoverflow.com/questions/tagged/questdb",
   twitterUrl: "https://twitter.com/questdb",
-  version: "5.0.6.1",
+  version: "6.0.0",
   videosUrl: "https://www.youtube.com/channel/UChqKEmOyiD9c6QFx2mjKwiA",
 }
 


### PR DESCRIPTION
This PR bumps the software version number and includes details on JDK versions for Maven users