### PR TITLE
chore: remove references to O3 rejections

### DIFF
--- a/docs/concept/designated-timestamp.md
+++ b/docs/concept/designated-timestamp.md
@@ -3,13 +3,12 @@ title: Designated timestamp
 sidebar_label: Designated timestamp
 description:
   How designated timestamps are implemented and why it is an important
-  functionality for time-series.
+  functionality for time series.
 ---
 
 QuestDB offers the option to elect a column as a _designated timestamp_. This
-allows you to leverage the high-performance time series features of QuestDB, but
-introduces a constraint on the timestamp column that will reject out-of-order
-inserts.
+allows you to specify which column the tables will be indexed by in order to
+leverage time-oriented language features and high-performance functionalities.
 
 ## Properties
 
@@ -22,11 +21,18 @@ inserts.
 
 ## Out-of-order policy
 
-Once a column is elected as a designated timestamp, it will enforce an order
-policy on this column, and out-of-order inserts will be rejected. In other
-words, new timestamp values need to be greater than or equal to the latest
-timestamp in the column. Columns other than the designated timestamp are not
-affected by this policy.
+As of version 6.0.0, QuestDB supports ingestion of records which are
+out-of-order (O3) by time. Configuring how the system handles ingestion of O3
+records is done via [O3 hysteresis](/docs/guides/hysteresis/) configuration.
+
+:::tip
+
+In versions prior to 6.0.0, once a column is elected as a designated timestamp,
+it will enforce an order policy on this column, and O3 inserts will be rejected.
+In other words, new timestamp values need to be greater than or equal to the
+latest timestamp in the column.
+
+:::
 
 ## Advantages
 
@@ -36,85 +42,3 @@ Electing a designated timestamp allows you to:
   [partitions reference](/docs/concept/partitions/).
 - Use time series joins such as `ASOF JOIN`. For more information, see the
   [JOIN reference](/docs/reference/sql/join/).
-
-## Illustration
-
-The following diagrams illustrate the effect of inserting new records when a
-table has a designated timestamp. The designated timestamp column only allows
-timestamps with greater than or equal values.
-
-Attempting to insert records with out-of-order timestamps will result in the
-record being rejected, and QuestDB will log an error for the `INSERT` statement:
-
-import Screenshot from "@theme/Screenshot"
-
-<Screenshot
-  alt="Diagram of an out of order insertion being rejected"
-  height={662}
-  src="/img/docs/concepts/timestampReject.svg"
-  width={745}
-/>
-
-Other `timestamp` type columns may have values inserted in any order:
-
-<Screenshot
-  alt="Comparison between a designated timestamp and a normal timestamp"
-  height={620}
-  src="/img/docs/concepts/designatedTimestamp.svg"
-  width={745}
-/>
-
-## Working with timestamp order constraint
-
-It may be impractical to enforce an ordered constraint on the timestamp column.
-There are two approaches that can be used in such cases:
-
-1. Use the database host clock as designated timestamp by using
-   `systimestamp()`. For more information about `systimestamp()`, see the
-   [date & time functions](/docs/reference/function/date-time/) reference.
-
-   ```questdb-sql title="The db_ts column is specified as designated timestamp"
-   CREATE TABLE readings(
-   	db_ts timestamp,
-   	device_ts timestamp,
-   	device_name symbol,
-   	reading int)
-   timestamp(db_ts);
-   ```
-
-   ```questdb-sql title="Using system timestamp while retaining the device timestamp"
-   INSERT INTO readings VALUES(
-   	systimestamp(),
-   	to_timestamp('2020-03-01:15:43:21', 'yyyy-MM-dd:HH:mm:ss'),
-   	'my_sensor',
-   	123);
-   ```
-
-2. Use a temporary table with out-of-order data:
-
-   ```questdb-sql title="Main table with designated timestamp"
-   CREATE TABLE readings(
-   	db_ts timestamp,
-   	device_ts timestamp,
-   	device_name symbol,
-   	reading int)
-   	timestamp(db_ts)
-   PARTITION BY DAY;
-   ```
-
-   ```questdb-sql title="Temporary table which may have out-of-order data"
-   CREATE TABLE readings_temp(
-   	db_ts timestamp,
-   	device_ts timestamp,
-   	device_name symbol,
-   	reading int);
-   ```
-
-   Data in the temporary table can then be ordered and inserted into the main
-   table. This can be a scheduled task run at the interval that the table is
-   partitioned by:
-
-   ```questdb-sql title="Order and insert data"
-   INSERT INTO readings
-   	SELECT * FROM (readings_temp ORDER BY db_ts) timestamp(db_ts);
-   ```

--- a/docs/concept/partitions.md
+++ b/docs/concept/partitions.md
@@ -25,14 +25,13 @@ import Screenshot from "@theme/Screenshot"
 - Partitions are defined at table creation. For more information, refer to
   [CREATE TABLE section](/docs/reference/sql/create-table/).
 
-## Requirements
+:::info
 
-Partition is only available on tables with a designated timestamp. The main
-benefit of using a designated timestamp is that the field in question will
-enforce an increasing policy on timestamp value. This allows you to leverage
-specific high-performance time series functions. For more information on
-designated timestamp, refer to the
+Partitioning is only possible on tables which have a designated timestamp. For
+more information on designated timestamps, refer to the
 [designated timestamp section](/docs/concept/designated-timestamp/).
+
+:::
 
 ## Advantages
 
@@ -52,13 +51,13 @@ has been partitioned using `PARTITION BY MONTH`.
 
 ```
 [quest-user trips]$ dir
-2017-03	    2017-10 	2018-05	    2019-02
-2017-04	    2017-11 	2018-06	    2019-03
-2017-05	    2017-12 	2018-07	    2019-04
-2017-06	    2018-01 	2018-08 	2019-05
-2017-07	    2018-02 	2018-09 	2019-06
-2017-08	    2018-03 	2018-10
-2017-09	    2018-04 	2018-11
+2017-03     2017-10   2018-05     2019-02
+2017-04     2017-11   2018-06     2019-03
+2017-05     2017-12   2018-07     2019-04
+2017-06     2018-01   2018-08   2019-05
+2017-07     2018-02   2018-09   2019-06
+2017-08     2018-03   2018-10
+2017-09     2018-04   2018-11
 ```
 
 Each partition on the disk contains the column data files of the corresponding

--- a/docs/operations/capacity-planning.md
+++ b/docs/operations/capacity-planning.md
@@ -181,30 +181,6 @@ few records per partition and having query operations across too many partitions
 has the result of slower query times. A general guideline is that roughly
 between 1 million and 100 million records is optimal per partition.
 
-### Timestamps
-
-Tables which have a designated timestamp expect new records to have a more
-recent timestamp than the last-inserted record. For this reason, out of order
-records are ignored by the system.
-
-**System timestamp:**
-
-One approach to mitigate the loss of records which have out-of-order timestamps
-is to allow the server to assign a timestamp for an incoming record which is
-equal to the time of ingestion:
-
-```questdb-sql title="Using server time for new inserts"
-INSERT INTO readings
-VALUES(systimestamp(), 123.4)
-```
-
-When using InfluxDB line protocol, omitting a timestamp value from incoming
-records has the same effect of an implicit `systimestamp()` function:
-
-```bash title="InfluxDB line protocol without a timestamp"
-readings,city=London,temperature=23.5,humidity=0.343
-```
-
 ### Choosing a schema
 
 This section provides some hints for choosing the right schema for a dataset

--- a/docs/reference/sql/create-table.md
+++ b/docs/reference/sql/create-table.md
@@ -179,17 +179,18 @@ information on the concepts introduced to below, see
 - [symbol](/docs/concept/symbol/) reference for using the `symbol` data type
 
 This example will create a table without a designated timestamp and does not
-have a partitioning strategy applied. New records may be ingested which have
-timestamp values out of order.
+have a partitioning strategy applied.
 
 ```questdb-sql title="Basic example"
 CREATE TABLE
 my_table(symb SYMBOL, price DOUBLE, ts TIMESTAMP, s STRING);
 ```
 
-The same table can be created and a designated timestamp may be specified.
-Tables with designated timestamps enforce that new timestamp values appear in
-chronological order.
+The same table can be created and a designated timestamp may be specified. New
+records with timestamps which are out-of-order (O3) chronologically will be
+ordered at the point of ingestion. Configuring how the system handles ingestion
+of O3 records is done via [O3 hysteresis](/docs/guides/hysteresis/)
+configuration.
 
 ```questdb-sql title="Adding a designated timestamp"
 CREATE TABLE


### PR DESCRIPTION
Reference to O3 rejections is no longer applicable as of 6.0