### PR TITLE
update docs with table metadata functions, regex examples

### DIFF
--- a/docs/concept/designated-timestamp.md
+++ b/docs/concept/designated-timestamp.md
@@ -10,6 +10,14 @@ QuestDB offers the option to elect a column as a _designated timestamp_. This
 allows you to specify which column the tables will be indexed by in order to
 leverage time-oriented language features and high-performance functionalities.
 
+:::info
+
+Checking if tables contain a designated timestamp column can be done via the
+`tables()` and `table_columns()` functions which are described in the
+[meta functions](/docs/reference/function/meta/) documentation page.
+
+:::
+
 ## Properties
 
 - Only a column of type `timestamp` can be elected as a designated timestamp.

--- a/docs/guides/hysteresis.md
+++ b/docs/guides/hysteresis.md
@@ -167,8 +167,20 @@ select id, name, o3MaxUncommittedRows, o3CommitHysteresisMicros from tables();
 
 | id  | name        | o3MaxUncommittedRows | o3CommitHysteresisMicros |
 | --- | ----------- | -------------------- | ------------------------ |
-| 1   | my_table    | 500000               | 300000000                |
+| 1   | my_table    | 250000               | 240000000                |
 | 2   | device_data | 10000                | 30000000                 |
+
+The values can changed per each table with:
+
+```questdb-sql title="Altering hysteresis o3MaxUncommittedRows parameter via SQL"
+ALTER TABLE my_table SET PARAM o3MaxUncommittedRows = 10s
+```
+
+and 
+
+```questdb-sql title="Altering hysteresis o3CommitHysteresis parameter via SQL"
+ALTER TABLE my_table SET PARAM o3CommitHysteresis = 20s
+```
 
 For more information on checking table metadata, see the
 [meta functions](/docs/reference/function/meta/) documentation page.

--- a/docs/guides/hysteresis.md
+++ b/docs/guides/hysteresis.md
@@ -162,13 +162,13 @@ PARTITION BY DAY WITH o3MaxUncommittedRows=250000, o3CommitHysteresis=240s
 Checking the values per-table may be done using the `tables()` function:
 
 ```questdb-sql title="List all tables"
-select id, name, maxUncommittedRows, o3CommitHysteresisMicros from tables();
+select id, name, o3MaxUncommittedRows, o3CommitHysteresisMicros from tables();
 ```
 
-| id  | name        | maxUncommittedRows | o3CommitHysteresisMicros |
-| --- | ----------- | ------------------ | ------------------------ |
-| 1   | my_table    | 500000             | 300000000                |
-| 2   | device_data | 10000              | 30000000                 |
+| id  | name        | o3MaxUncommittedRows | o3CommitHysteresisMicros |
+| --- | ----------- | -------------------- | ------------------------ |
+| 1   | my_table    | 500000               | 300000000                |
+| 2   | device_data | 10000                | 30000000                 |
 
 For more information on checking table metadata, see the
 [meta functions](/docs/reference/function/meta/) documentation page.

--- a/docs/guides/hysteresis.md
+++ b/docs/guides/hysteresis.md
@@ -144,9 +144,12 @@ docker run -p 8812:8812 -p 9000:9000 -p 9009:9009 \
   questdb/questdb
 ```
 
-O3 hysteresis parameters may also be set during table creation as part of the
-`PARTITION BY` clause. When passed in this way using the `WITH` keyword, the
-following two parameters may be applied:
+### Per-table configuration
+
+Aside from 'global' server hysteresis settings, it's possible to set O3
+hysteresis parameters during table creation as part of the `PARTITION BY`
+clause. When passed in this way using the `WITH` keyword, the following two
+parameters may be applied:
 
 - `o3MaxUncommittedRows` - equivalent to `cairo.o3.max.uncommitted.rows`
 - `o3CommitHysteresis` - equivalent to `cairo.o3.commit.hysteresis.in.ms`
@@ -155,3 +158,17 @@ following two parameters may be applied:
 CREATE TABLE my_table (timestamp TIMESTAMP) timestamp(timestamp)
 PARTITION BY DAY WITH o3MaxUncommittedRows=250000, o3CommitHysteresis=240s
 ```
+
+Checking the values per-table may be done using the `tables()` function:
+
+```questdb-sql title="List all tables"
+select id, name, maxUncommittedRows, o3CommitHysteresisMicros from tables();
+```
+
+| id  | name        | maxUncommittedRows | o3CommitHysteresisMicros |
+| --- | ----------- | ------------------ | ------------------------ |
+| 1   | my_table    | 500000             | 300000000                |
+| 2   | device_data | 10000              | 30000000                 |
+
+For more information on checking table metadata, see the
+[meta functions](/docs/reference/function/meta/) documentation page.

--- a/docs/reference/api/java-embedded.md
+++ b/docs/reference/api/java-embedded.md
@@ -18,7 +18,6 @@ import TabItem from "@theme/TabItem"
 
 <TabItem value="maven">
 
-
 ```xml title="JDK11"
 <dependency>
     <groupId>org.questdb</groupId>

--- a/docs/reference/function/conditional.md
+++ b/docs/reference/function/conditional.md
@@ -4,6 +4,10 @@ sidebar_label: Conditional
 description: Conditional functions reference documentation.
 ---
 
+Conditionally functions allow for conditionally selecting input values. The
+`coalesce()` function is useful for handling null data values and providing
+replacement values.
+
 ## coalesce
 
 `coalesce(value [, ...])` - returns the first non-null argument in a provided

--- a/docs/reference/function/date-time.md
+++ b/docs/reference/function/date-time.md
@@ -4,6 +4,17 @@ sidebar_label: Date and time
 description: Date and time functions reference documentation.
 ---
 
+This page describes the available functions to assist with performing time-based
+calculations.
+
+:::info
+
+Checking if tables contain a designated timestamp column can be done via the
+`tables()` and `table_columns()` functions which are described in the
+[meta functions](/docs/reference/function/meta/) documentation page.
+
+:::
+
 ## systimestamp
 
 `systimestamp()` - offset from UTC Epoch in microseconds. Calculates

--- a/docs/reference/function/meta.md
+++ b/docs/reference/function/meta.md
@@ -4,51 +4,10 @@ sidebar_label: Meta
 description: Table and database metadata function reference documentation.
 ---
 
-## tables
-
-`tables()` returns all tables in the database including table metadata.
-
-**Arguments:**
-
-- `tables()` does not require arguments.
-
-**Return value:**
-
-Returns a `table`.
-
-**Examples:**
-
-```questdb-sql title="List all tables"
-tables();
-```
-
-```txt
-| id  | name        | designatedTimestamp | partitionBy | maxUncommittedRows | o3CommitHysteresisMicros |
-| --- | ----------- | ------------------- | ----------- | ------------------ | ------------------------ |
-| 1   | my_table    | ts                  | DAY         | 500000             | 300000000                |
-| 2   | device_data | null                | NONE        | 10000              | 30000000                 |
-```
-
-```questdb-sql title="All tables in reverse alphabetical order"
-tables() ORDER BY name DESC;
-```
-
-```txt
-| id  | name        | designatedTimestamp | partitionBy | maxUncommittedRows | o3CommitHysteresisMicros |
-| --- | ----------- | ------------------- | ----------- | ------------------ | ------------------------ |
-| 2   | device_data | null                | NONE        | 10000              | 30000000                 |
-| 1   | my_table    | ts                  | DAY         | 500000             | 300000000                |
-```
-
-```questdb-sql title="All tables with a daily partitioning strategy"
-tables() WHERE partitionBy = 'DAY'
-```
-
-```txt
-| id  | name        | designatedTimestamp | partitionBy | maxUncommittedRows | o3CommitHysteresisMicros |
-| --- | ----------- | ------------------- | ----------- | ------------------ | ------------------------ |
-| 1   | my_table    | ts                  | DAY         | 500000             | 300000000                |
-```
+These functions provide table information including column details and metadata
+such as [hysteresis parameters](/docs/guides/hysteresis/). These functions are
+particularly useful for checking if tables contain a
+[designated timestamp](/docs/concept/designated-timestamp) column.
 
 ## table_columns
 
@@ -60,7 +19,7 @@ tables() WHERE partitionBy = 'DAY'
 
 **Return value:**
 
-Returns a `table` with two columns:
+Returns a `table` with the following columns:
 
 - `column` - name of the available columns in the table
 - `type` - type of the column
@@ -82,34 +41,70 @@ For more details on the meaning and use of these values, see the
 table_columns('my_table')
 ```
 
-```txt
 | column | type      | indexed | indexBlockCapacity | symbolCached | symbolCapacity | designated |
 | ------ | --------- | ------- | ------------------ | ------------ | -------------- | ---------- |
 | symb   | SYMBOL    | true    | 1048576            | false        | 256            | false      |
 | price  | DOUBLE    | false   | 0                  | false        | 0              | false      |
 | ts     | TIMESTAMP | false   | 0                  | false        | 0              | true       |
 | s      | STRING    | false   | 0                  | false        | 0              | false      |
-```
 
 ```questdb-sql title="Get designated timestamp column"
 SELECT column, type, designated FROM table_columns('my_table') WHERE designated
 ```
 
-```txt
 | column | type      | designated |
 | ------ | --------- | ---------- |
 | ts     | TIMESTAMP | true       |
-```
 
 ```questdb-sql title="Get the count of column types"
 SELECT type, count() FROM table_columns('my_table');
 ```
 
-```txt
 | type      | count |
 | --------- | ----- |
 | SYMBOL    | 1     |
 | DOUBLE    | 1     |
 | TIMESTAMP | 1     |
 | STRING    | 1     |
+
+
+## tables
+
+`tables()` returns all tables in the database including table metadata.
+
+**Arguments:**
+
+- `tables()` does not require arguments.
+
+**Return value:**
+
+Returns a `table`.
+
+**Examples:**
+
+```questdb-sql title="List all tables"
+tables();
 ```
+
+| id  | name        | designatedTimestamp | partitionBy | maxUncommittedRows | o3CommitHysteresisMicros |
+| --- | ----------- | ------------------- | ----------- | ------------------ | ------------------------ |
+| 1   | my_table    | ts                  | DAY         | 500000             | 300000000                |
+| 2   | device_data | null                | NONE        | 10000              | 30000000                 |
+
+```questdb-sql title="All tables in reverse alphabetical order"
+tables() ORDER BY name DESC;
+```
+
+| id  | name        | designatedTimestamp | partitionBy | maxUncommittedRows | o3CommitHysteresisMicros |
+| --- | ----------- | ------------------- | ----------- | ------------------ | ------------------------ |
+| 2   | device_data | null                | NONE        | 10000              | 30000000                 |
+| 1   | my_table    | ts                  | DAY         | 500000             | 300000000                |
+
+```questdb-sql title="All tables with a daily partitioning strategy"
+tables() WHERE partitionBy = 'DAY'
+```
+
+| id  | name     | designatedTimestamp | partitionBy | maxUncommittedRows | o3CommitHysteresisMicros |
+| --- | -------- | ------------------- | ----------- | ------------------ | ------------------------ |
+| 1   | my_table | ts                  | DAY         | 500000             | 300000000                |
+

--- a/docs/reference/function/meta.md
+++ b/docs/reference/function/meta.md
@@ -67,7 +67,6 @@ SELECT type, count() FROM table_columns('my_table');
 | TIMESTAMP | 1     |
 | STRING    | 1     |
 
-
 ## tables
 
 `tables()` returns all tables in the database including table metadata.
@@ -107,4 +106,3 @@ tables() WHERE partitionBy = 'DAY'
 | id  | name     | designatedTimestamp | partitionBy | maxUncommittedRows | o3CommitHysteresisMicros |
 | --- | -------- | ------------------- | ----------- | ------------------ | ------------------------ |
 | 1   | my_table | ts                  | DAY         | 500000             | 300000000                |
-

--- a/docs/reference/function/meta.md
+++ b/docs/reference/function/meta.md
@@ -85,24 +85,24 @@ Returns a `table`.
 tables();
 ```
 
-| id  | name        | designatedTimestamp | partitionBy | maxUncommittedRows | o3CommitHysteresisMicros |
-| --- | ----------- | ------------------- | ----------- | ------------------ | ------------------------ |
-| 1   | my_table    | ts                  | DAY         | 500000             | 300000000                |
-| 2   | device_data | null                | NONE        | 10000              | 30000000                 |
+| id  | name        | designatedTimestamp | partitionBy | o3MaxUncommittedRows | o3CommitHysteresisMicros |
+| --- | ----------- | ------------------- | ----------- | -------------------- | ------------------------ |
+| 1   | my_table    | ts                  | DAY         | 500000               | 300000000                |
+| 2   | device_data | null                | NONE        | 10000                | 30000000                 |
 
 ```questdb-sql title="All tables in reverse alphabetical order"
 tables() ORDER BY name DESC;
 ```
 
-| id  | name        | designatedTimestamp | partitionBy | maxUncommittedRows | o3CommitHysteresisMicros |
-| --- | ----------- | ------------------- | ----------- | ------------------ | ------------------------ |
-| 2   | device_data | null                | NONE        | 10000              | 30000000                 |
-| 1   | my_table    | ts                  | DAY         | 500000             | 300000000                |
+| id  | name        | designatedTimestamp | partitionBy | o3MaxUncommittedRows | o3CommitHysteresisMicros |
+| --- | ----------- | ------------------- | ----------- | -------------------- | ------------------------ |
+| 2   | device_data | null                | NONE        | 10000                | 30000000                 |
+| 1   | my_table    | ts                  | DAY         | 500000               | 300000000                |
 
 ```questdb-sql title="All tables with a daily partitioning strategy"
 tables() WHERE partitionBy = 'DAY'
 ```
 
-| id  | name     | designatedTimestamp | partitionBy | maxUncommittedRows | o3CommitHysteresisMicros |
-| --- | -------- | ------------------- | ----------- | ------------------ | ------------------------ |
-| 1   | my_table | ts                  | DAY         | 500000             | 300000000                |
+| id  | name     | designatedTimestamp | partitionBy | o3MaxUncommittedRows | o3CommitHysteresisMicros |
+| --- | -------- | ------------------- | ----------- | -------------------- | ------------------------ |
+| 1   | my_table | ts                  | DAY         | 500000               | 300000000                |

--- a/docs/reference/function/numeric.md
+++ b/docs/reference/function/numeric.md
@@ -4,6 +4,9 @@ sidebar_label: Numeric
 description: Numeric function reference documentation.
 ---
 
+This page describes the available functions to assist with performing numeric
+calculations.
+
 ## abs
 
 `abs(value)` return the absolute value. The behavior of `abs` is as follows:

--- a/docs/reference/function/row-generator.md
+++ b/docs/reference/function/row-generator.md
@@ -4,6 +4,15 @@ sidebar_label: Row generator
 description: Row generator function reference documentation.
 ---
 
+The `long_sequence()` function may be used as a row generator to create table
+data for testing. Basic usage of this function involves providing the number of
+iterations required. Deterministic pseudo-random behavior can be achieved by
+providing seed values when calling the function.
+
+This function is commonly used in combination with
+[random generator functions](/docs/reference/function/random-value-generator/)
+to produce mock data.
+
 ## long_sequence
 
 - `long_sequence(iterations)` - generates rows
@@ -16,18 +25,14 @@ and `seed2` are `long64` representing both parts of a `long128` seed.
 
 ### Row generation
 
+The `long_sequence()` function can be used to generate very large datasets for
+testing e.g. billions of rows.
+
 `long_sequence(iterations)` is used to:
 
 - Generate a number of rows defined by `iterations`.
 - Generate a column `x:long` of monotonically increasing long integers starting
   from 1, which can be accessed for queries.
-
-:::tip
-
-You can use this to generate very large datasets for your testing e.g billions
-of rows or more if your disk allows.
-
-:::
 
 ### Random number seed
 
@@ -36,7 +41,7 @@ When `long_sequence` is used conjointly with
 values are usually generated at random. The function supports a seed to be
 passed in order to produce deterministic results.
 
-:::tip
+:::info
 
 Deterministic procedural generation makes it easy to test on vasts amounts of
 data without actually moving large files around across machines. Using the same

--- a/docs/reference/function/text.md
+++ b/docs/reference/function/text.md
@@ -78,11 +78,15 @@ SELECT name a, length(name) b FROM names limit 4
 
 `string ~ regex` - matches `string` value to regex
 
+`symbol ~ regex` - matches `symbol` value to regex
+
 [java.util.regex](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html)
 
 ## !~
 
 `string !~ regex` - checks if `string` value does not match regex
+
+`symbol !~ regex` - checks if `symbol` value does not match regex
 
 ## to_lowercase
 

--- a/docs/reference/function/text.md
+++ b/docs/reference/function/text.md
@@ -74,19 +74,15 @@ SELECT name a, length(name) b FROM names limit 4
 | TOM    | 3   |
 | null   | -1  |
 
-## ~=
+## ~
 
-`~=(string, regex)` - matches `string` value to regex
-
-`~=(symbol, regex)` - matches `symbol` value to regex
+`string ~ regex` - matches `string` value to regex
 
 [java.util.regex](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html)
 
 ## !~
 
-`!~(string, regex)` - checks if `string` value does not match regex
-
-`!~(symbol, regex)` - checks if `symbol` value does not match regex
+`string !~ regex` - checks if `string` value does not match regex
 
 ## to_lowercase
 

--- a/docs/reference/function/text.md
+++ b/docs/reference/function/text.md
@@ -4,6 +4,10 @@ sidebar_label: Text
 description: Text function reference documentation.
 ---
 
+This page describes the available functions to assist with performing text
+manipulation such as concatenation, case conversion, string length calculation,
+and pattern matching via regular expressions.
+
 ## concat
 
 `concat(str, ...)` - concatenates a string from one or more input values.

--- a/docs/reference/function/timestamp-generator.md
+++ b/docs/reference/function/timestamp-generator.md
@@ -4,6 +4,12 @@ sidebar_label: Timestamp generator
 description: Timestamp generator function reference documentation.
 ---
 
+The `timestamp_sequence()` function may be used as a timestamp generator to
+create data for testing. Pseudo-random steps can be achieved by providing a
+[random function](/docs/reference/function/random-value-generator/) to the
+`step` argument. A `seed` value may be provided to a random function if the
+randomly-generated `step` should be deterministic.
+
 ## timestamp_sequence
 
 - `timestamp_sequence(startTimestamp, step)` generates a sequence of `timestamp`

--- a/docs/reference/function/timestamp.md
+++ b/docs/reference/function/timestamp.md
@@ -10,36 +10,33 @@ description: Timestamp function reference documentation.
 - during a [CREATE TABLE](/docs/reference/sql/create-table/#timestamp) operation
 - during a [SELECT](/docs/reference/sql/select/) operation (`dynamic timestamp`)
 
+:::info
+
+Checking if tables contain a designated timestamp column can be done via the
+`tables()` and `table_columns()` functions which are described in the
+[meta functions](/docs/reference/function/meta/) documentation page.
+
+:::
+
 ## Syntax
 
 ### During a CREATE operation
-
-![Flow chart showing the syntax of the TIMESTAMP keyword](/img/docs/diagrams/timestamp.svg)
 
 Create a [designated timestamp](/docs/concept/designated-timestamp/) column
 during table creation. For more information, refer to the
 [CREATE TABLE](/docs/reference/sql/create-table/) section.
 
+![Flow chart showing the syntax of the TIMESTAMP keyword](/img/docs/diagrams/timestamp.svg)
+
 ### During a SELECT operation
 
-![Flow chart showing the syntax of the timestamp function](/img/docs/diagrams/dynamicTimestamp.svg)
-
 Creates a [designated timestamp](/docs/concept/designated-timestamp/) column in
-the result of a query.
+the result of a query. Assigning a timestamp in a `SELECT` statement
+(`dynamic timestamp`) allows for time series operations such as `LATEST BY`,
+`SAMPLE BY` or `LATEST BY` on tables which do not have a `designated timestamp`
+assigned.
 
-:::caution
-
-The output query must be ordered by time. `TIMESTAMP()` does not check for order
-and using timestamp functions on unordered data may produce unexpected results.
-
-:::
-
-:::tip
-
-Dynamic timestamp allows to perform time series operations such as `LATEST BY`,
-`SAMPLE BY` or `LATEST BY` on tables which do not have a `designated timestamp`.
-
-:::
+![Flow chart showing the syntax of the timestamp function](/img/docs/diagrams/dynamicTimestamp.svg)
 
 ## Examples
 

--- a/docs/reference/sql/show.md
+++ b/docs/reference/sql/show.md
@@ -4,14 +4,17 @@ sidebar_label: SHOW
 description: SHOW SQL keyword reference documentation.
 ---
 
-Displays tables and columns available in the database.
+This keyword provides column and table information including metadata such as
+[hysteresis parameters](/docs/guides/hysteresis/). The `SHOW` keyword is useful
+for checking if tables contain a
+[designated timestamp](/docs/concept/designated-timestamp) column.
 
 :::info
 
 These commands return the tables and columns as a table. If you would like to
 query your tables and columns with filters or to use the results as part of a
 function, see [table_columns()](/docs/reference/function/meta/#table_columns)
-and [all_tables()](/docs/reference/function/meta/#all_tables) functions.
+and [tables()](/docs/reference/function/meta/#all_tables) functions.
 
 :::
 
@@ -23,21 +26,21 @@ Show all tables:
 SHOW TABLES;
 ```
 
-| tableName |
-| --------- |
-| table1    |
-| table2    |
-| ...       |
+| table    |
+| -------- |
+| weather  |
+| my_table |
+| ...      |
 
-Show all columns for table `weather`
+Show all columns for table `my_table`
 
 ```questdb-sql
-SHOW COLUMNS FROM myTable;
+SHOW COLUMNS FROM my_table;
 ```
 
-| columnName | type      |
-| ---------- | --------- |
-| column1    | timestamp |
-| column2    | int       |
-| column3    | SYMBOL    |
-| ...        | ...       |
+| column | type      | indexed | indexBlockCapacity | symbolCached | symbolCapacity | designated |
+| ------ | --------- | ------- | ------------------ | ------------ | -------------- | ---------- |
+| symb   | SYMBOL    | true    | 1048576            | false        | 256            | false      |
+| price  | DOUBLE    | false   | 0                  | false        | 0              | false      |
+| ts     | TIMESTAMP | false   | 0                  | false        | 0              | true       |
+| s      | STRING    | false   | 0                  | false        | 0              | false      |

--- a/docs/reference/sql/where.md
+++ b/docs/reference/sql/where.md
@@ -74,7 +74,6 @@ patterns.
 
 ![Flow chart showing the syntax of the WHERE clause with a regex comparison](/img/docs/diagrams/whereRegexMatch.svg)
 
-
 ```questdb-sql title="Regex example"
 SELECT * FROM users WHERE name ~ 'Jo';
 ```
@@ -84,7 +83,6 @@ SELECT * FROM users WHERE name ~ 'Jo';
 | Joe      | 31  |
 | Jonathan | 45  |
 | ...      | ... |
-
 
 ### Regular expression does NOT match
 

--- a/docs/reference/sql/where.md
+++ b/docs/reference/sql/where.md
@@ -74,6 +74,7 @@ patterns.
 
 ![Flow chart showing the syntax of the WHERE clause with a regex comparison](/img/docs/diagrams/whereRegexMatch.svg)
 
+
 ```questdb-sql title="Regex example"
 SELECT * FROM users WHERE name ~ 'Jo';
 ```

--- a/docs/reference/sql/where.md
+++ b/docs/reference/sql/where.md
@@ -74,8 +74,9 @@ patterns.
 
 ![Flow chart showing the syntax of the WHERE clause with a regex comparison](/img/docs/diagrams/whereRegexMatch.svg)
 
-```questdb-sql title="Example"
-SELECT * FROM users WHERE ~=(name, 'Jo');
+
+```questdb-sql title="Regex example"
+SELECT * FROM users WHERE name ~ 'Jo';
 ```
 
 | name     | age |
@@ -83,6 +84,7 @@ SELECT * FROM users WHERE ~=(name, 'Jo');
 | Joe      | 31  |
 | Jonathan | 45  |
 | ...      | ... |
+
 
 ### Regular expression does NOT match
 
@@ -93,7 +95,7 @@ patterns.
 ![Flow chart showing the syntax of the WHERE clause with a regex comparison](/img/docs/diagrams/whereRegexNotMatch.svg)
 
 ```questdb-sql title="Example"
-SELECT * FROM users WHERE !~(name, 'Jo');
+SELECT * FROM users WHERE name !~ 'Jo';
 ```
 
 | name | age |

--- a/sidebars.js
+++ b/sidebars.js
@@ -68,7 +68,7 @@ module.exports = {
       label: "Guides",
       type: "category",
       items: [
-       "guides/v6-migration",
+        "guides/v6-migration",
         {
           label: "Ingestion",
           type: "category",

--- a/src/css/community/page.module.css
+++ b/src/css/community/page.module.css
@@ -256,7 +256,7 @@
   width: 50px;
 }
 
-@media (min-width:997px) and (max-width:1121px){
+@media (min-width: 997px) and (max-width: 1121px) {
   .custom_input,
   .signup_button {
     width: 100%;

--- a/static/img/docs/diagrams/whereRegexMatch.svg
+++ b/static/img/docs/diagrams/whereRegexMatch.svg
@@ -29,26 +29,17 @@
         </style>
     </defs>
     <polygon points="9 17 1 13 1 21"/>
-    <polygon points="17 17 9 13 9 21"/>
-    <rect x="31" y="3" width="70" height="32" rx="10"/>
-    <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="39" y="21">WHERE</text>
-    <rect x="121" y="3" width="40" height="32" rx="10"/>
-    <rect x="119" y="1" width="40" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="129" y="21">~=</text>
-    <rect x="181" y="3" width="26" height="32" rx="10"/>
-    <rect x="179" y="1" width="26" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="189" y="21">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column" xlink:title="column">
-    <rect x="227" y="3" width="64" height="32"/>
-    <rect x="225" y="1" width="64" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="235" y="21">column</text></a><rect x="311" y="3" width="24" height="32" rx="10"/>
-    <rect x="309" y="1" width="24" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="319" y="21">;</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#regex" xlink:title="regex">
-    <rect x="355" y="3" width="56" height="32"/>
-    <rect x="353" y="1" width="56" height="32" class="nonterminal"/>
-    <text class="nonterminal" x="363" y="21">regex</text></a><rect x="431" y="3" width="26" height="32" rx="10"/>
-    <rect x="429" y="1" width="26" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="439" y="21">)</text>
-    <path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"/>
-    <polygon points="475 17 483 13 483 21"/>
-    <polygon points="475 17 467 13 467 21"/></svg>
+         <polygon points="17 17 9 13 9 21"/>
+         <rect x="31" y="3" width="70" height="32" rx="10"/>
+         <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="39" y="21">WHERE</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#column" xlink:title="column">
+            <rect x="121" y="3" width="64" height="32"/>
+            <rect x="119" y="1" width="64" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="129" y="21">column</text></a><rect x="205" y="3" width="30" height="32" rx="10"/>
+         <rect x="203" y="1" width="30" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="213" y="21">~</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#regex" xlink:title="regex">
+            <rect x="255" y="3" width="56" height="32"/>
+            <rect x="253" y="1" width="56" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="263" y="21">regex</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m56 0 h10 m3 0 h-3"/>
+         <polygon points="329 17 337 13 337 21"/>
+         <polygon points="329 17 321 13 321 21"/></svg>


### PR DESCRIPTION
This PR contains the following additions:

* `tables()` and meta functions updated with most recent example of returned rows, hints on checking designated timestamp
* regex operator usage changed from `~=(string, pattern)` to `string ~ pattern`
* additional hints to table metadata functions
* railroad diagram updates
* per-table hysteresis configuration `WITH <o3_config>`