### PR TITLE
docs: 6.0.1 timestamp changes

### DIFF
--- a/blog/2021-05-10-questdb-release-6-0-tsbs-benchmark.md
+++ b/blog/2021-05-10-questdb-release-6-0-tsbs-benchmark.md
@@ -1,5 +1,5 @@
 ---
-title: Building a new vector based storage model
+title: How we achieved write speeds of 1.4 million rows per second
 author: Vlad Ilyushchenko
 author_title: QuestDB Team
 author_url: https://github.com/bluestreak01

--- a/docs/guides/v6-migration.md
+++ b/docs/guides/v6-migration.md
@@ -76,3 +76,119 @@ mv db/sensors/_txn.v417 db/sensors/_txn
 
 After these steps have been completed, QuestDB v5.x may be started and the table
 data will be loaded as usual.
+
+### Breaking SQL changes
+
+Release 6.0.1 has few breaking SQL syntax changes in order to simplify working with TIMESTAMP type in queries and make SQL syntax more in line with ANSI SQL expectations.
+
+Below examples show the difference in query results for talbe `my_table` containing 48 records with timestamp every hour beginning from 00:00:00 on 2020-01-01
+
+| timestamp                   | 
+| --------------------------- |
+| 2020-01-01T00:00:00.000000Z |
+| 2020-01-01T01:00:00.000000Z |
+| 2020-01-01T02:00:00.000000Z |
+| 2020-01-01T03:00:00.000000Z |
+| ...                         |
+| 2020-01-01T23:00:00.000000Z |
+| 2020-01-02T00:00:00.000000Z |
+| 2020-01-02T01:00:00.000000Z |
+| ...                         |
+| 2020-01-02T23:00:00.000000Z |
+
+#### Timestamp String equality
+
+Example query
+
+```questdb-sql title="timestamp string equality"
+SELECT * FROM my_table
+WHERE timestamp = '2020-01-01'
+```
+Before 6.0.1 this would result in 24 records of all hours during date '2020-01-01'
+
+| timestamp                   | 
+| --------------------------- |
+| 2020-01-01T00:00:00.000000Z |
+| 2020-01-01T01:00:00.000000Z |
+| 2020-01-01T02:00:00.000000Z |
+| 2020-01-01T03:00:00.000000Z |
+| ...                         |
+| 2020-01-01T23:00:00.000000Z |
+
+After 6.0.1 the result will be 1 record with exact match of `2020-01-01T00:00:00.000000Z`. 
+In other words string `2020-01-01` represents not an interval but a single TIMESTAMP data point of `2020-01-01T00:00:00.000000Z`
+
+| timestamp                   | 
+| --------------------------- |
+| 2020-01-01T00:00:00.000000Z |
+
+In order to use old sematics the query has to be re-written with `IN` instead of `=`
+
+```questdb-sql title="timestamp string equality old equivalent"
+SELECT * FROM my_table
+WHERE timestamp IN '2020-01-01'
+```
+
+#### Timestamp String comparision
+
+Example query
+
+```questdb-sql title="timestamp string equality"
+SELECT * FROM my_table
+WHERE timestamp > '2020-01-01'
+```
+Before 6.0.1 this would result in 24 records of all hours during date '2020-01-02'
+
+| timestamp                   | 
+| --------------------------- |
+| 2020-01-02T00:00:00.000000Z |
+| ...                         |
+| 2020-01-02T23:00:00.000000Z |
+
+After 6.0.1 the result will be 47 record with strictly greter of `2020-01-01T00:00:00.000000Z`.
+
+| timestamp                   | 
+| --------------------------- |
+| 2020-01-01T01:00:00.000000Z |
+| ...                         |
+| 2020-01-02T23:00:00.000000Z |
+
+
+In other words string `2020-01-01` represents not an interval but a single TIMESTAMP data point of `2020-01-01T00:00:00.000000Z`. 
+The equivalient to the old syntax is
+
+```questdb-sql title="timestamp string equality old equivalent"
+SELECT * FROM my_table
+WHERE timestamp >= '2020-01-02'
+```
+
+#### Timestamp IN list 
+
+Example query of timestamp used with `IN` operator with list of 2 elements
+
+```questdb-sql title="timestamp IN string list"
+SELECT * FROM my_table
+WHERE timestamp IN ('2020-01-01T00:00:00.000000Z', '2020-01-02T00:00:00.000000Z')
+```
+
+Before 6.0.1 this would result in 25 records of all hours during date `2020-01-01` and `00:00:00` time on `2020-01-02`
+
+| timestamp                   | 
+| --------------------------- |
+| 2020-01-02T00:00:00.000000Z |
+| ...                         |
+| 2020-01-02T00:00:00.000000Z |
+
+After 6.0.2 result will 2 records matching exactly '2020-01-01T00:00:00.000000Z' and '2020-01-02T00:00:00.000000Z'
+
+| timestamp                   | 
+| --------------------------- |
+| 2020-01-02T00:00:00.000000Z |
+| 2020-01-02T00:00:00.000000Z |
+
+The equivalient to the old syntax is operator BETWEEN
+
+```questdb-sql title="timestamp string equality old equivalent"
+SELECT * FROM my_table
+WHERE timestamp BETWEEN '2020-01-01T00:00:00.000000Z' AND '2020-01-02T00:00:00.000000Z'
+```

--- a/docs/reference/function/date-time.md
+++ b/docs/reference/function/date-time.md
@@ -165,7 +165,7 @@ values(to_timestamp('2019-12-12T12:15', 'yyyy-MM-ddTHH:mm'), 123.5);
 
 Note that convertion of ISO timestamp format is optional. 
 QuestDB automatically converts STRING to TIMESAMP if it is partial or full form of `yyyy-MM-ddTHH:mm:ss.SSSUUU` or `yyyy-MM-dd HH:mm:ss.SSSUUU` 
-with valid time offset `+01:00` or `Z`. See more examples at (Native timestamp format)[/docs/reference/sql/where#native-timestamp-format]
+with valid time offset `+01:00` or `Z`. See more examples at [Native timestamp format](/docs/reference/sql/where#native-timestamp-format)
 
 ## to_date
 

--- a/docs/reference/function/date-time.md
+++ b/docs/reference/function/date-time.md
@@ -162,6 +162,11 @@ values(to_timestamp('2019-12-12T12:15', 'yyyy-MM-ddTHH:mm'), 123.5);
 | --------------------------- | ----- |
 | 2019-12-12T12:15:00.000000Z | 123.5 |
 
+
+Note that convertion of ISO timestamp format is optional. 
+QuestDB automatically converts STRING to TIMESAMP if it is partial or full form of `yyyy-MM-ddTHH:mm:ss.SSSUUU` or `yyyy-MM-dd HH:mm:ss.SSSUUU` 
+with valid time offset `+01:00` or `Z`. See more examples at (Native timestamp format)[/docs/reference/sql/where#native-timestamp-format]
+
 ## to_date
 
 `to_date(string, format)` - converts string to `date` by using the supplied

--- a/docs/reference/function/date-time.md
+++ b/docs/reference/function/date-time.md
@@ -162,10 +162,11 @@ values(to_timestamp('2019-12-12T12:15', 'yyyy-MM-ddTHH:mm'), 123.5);
 | --------------------------- | ----- |
 | 2019-12-12T12:15:00.000000Z | 123.5 |
 
-
-Note that convertion of ISO timestamp format is optional. 
-QuestDB automatically converts STRING to TIMESAMP if it is partial or full form of `yyyy-MM-ddTHH:mm:ss.SSSUUU` or `yyyy-MM-dd HH:mm:ss.SSSUUU` 
-with valid time offset `+01:00` or `Z`. See more examples at [Native timestamp format](/docs/reference/sql/where#native-timestamp-format)
+Note that conversion of ISO timestamp format is optional. QuestDB automatically
+converts `STRING` to `TIMESTAMP` if it is partial or full form of
+`yyyy-MM-ddTHH:mm:ss.SSSUUU` or `yyyy-MM-dd HH:mm:ss.SSSUUU` with valid time
+offset `+01:00` or `Z`. See more examples at
+[Native timestamp format](/docs/reference/sql/where#native-timestamp-format)
 
 ## to_date
 

--- a/docs/reference/sql/where.md
+++ b/docs/reference/sql/where.md
@@ -212,6 +212,35 @@ based on inequality. This section describes the use of the
 designated timestamp can be applied
 [dynamically](/docs/reference/function/timestamp/#during-a-select-operation).
 
+### Native timestamp format
+
+QuestDB automatically recognizes string formatted as ISO timestamp as a timestamp type. Following are valid examples of timestamp strings
+
+| Valid STRING Format              |  Resulting Timestamp        |
+| -------------------------------- | --------------------------- |
+| 2010-01-12T12:35:26.123456+01:30 | 2010-01-12T14:05:26.123456Z |
+| 2010-01-12T12:35:26.123456+01    | 2010-01-12T13:35:26.123456Z |
+| 2010-01-12T12:35:26.123456Z      | 2010-01-12T12:35:26.123456Z |
+| 2010-01-12T12:35:26.12345        | 2010-01-12T12:35:26.123450Z |
+| 2010-01-12T12:35:26.1234         | 2010-01-12T12:35:26.123400Z |
+| 2010-01-12T12:35:26.123          | 2010-01-12T12:35:26.123000Z |
+| 2010-01-12T12:35:26.12           | 2010-01-12T12:35:26.120000Z |
+| 2010-01-12T12:35:26.1            | 2010-01-12T12:35:26.100000Z |
+| 2010-01-12T12:35:26              | 2010-01-12T12:35:26.000000Z |
+| 2010-01-12T12:35                 | 2010-01-12T12:35:00.000000Z |
+| 2010-01-12T12                    | 2010-01-12T12:00:00.000000Z |
+| 2010-01-12                       | 2010-01-12T00:00:00.000000Z |
+| 2010-01                          | 2010-01-01T00:00:00.000000Z |
+| 2010                             | 2010-01-01T00:00:00.000000Z |
+| 2010-01-12 12:35:26.123456-02:00 | 2010-01-12T10:35:26.123456Z |
+| 2010-01-12 12:35:26.123456Z      | 2010-01-12T14:05:26.123456Z |
+| 2010-01-12 12:35:26.123          | 2010-01-12T12:35:26.123000Z |
+| 2010-01-12 12:35:26.12           | 2010-01-12T12:35:26.120000Z |
+| 2010-01-12 12:35:26.1            | 2010-01-12T12:35:26.100000Z |
+| 2010-01-12 12:35:26              | 2010-01-12T12:35:26.000000Z |
+| 2010-01-12 12:35                 | 2010-01-12T12:35:00.000000Z |
+
+
 ### Exact timestamp
 
 #### Syntax
@@ -247,7 +276,7 @@ Return results within a defined range
 ![Flow chart showing the syntax of the WHERE clause with a partial timestamp comparison](/img/docs/diagrams/whereTimestampPartial.svg)
 
 ```questdb-sql title="Results in a given year"
-SELECT * FROM scores WHERE ts = '2018';
+SELECT * FROM scores WHERE ts in '2018';
 ```
 
 | ts                          | score |
@@ -257,7 +286,7 @@ SELECT * FROM scores WHERE ts = '2018';
 | 2018-12-31T23:59:59.999999Z | 115.8 |
 
 ```questdb-sql title="Results in a given minute"
-SELECT * FROM scores WHERE ts = '2018-05-23T12:15';
+SELECT * FROM scores WHERE ts in '2018-05-23T12:15';
 ```
 
 | ts                          | score |
@@ -282,7 +311,7 @@ by the modifier parameter.
 - A `negative` value reduces the interval.
 
 ```questdb-sql title="Results in a given year and the first month of the next year"
-SELECT * FROM scores WHERE ts = '2018;1M';
+SELECT * FROM scores WHERE ts in '2018;1M';
 ```
 
 The range is 2018. The modifier extends the upper bound (originally 31 Dec 2018)
@@ -295,7 +324,7 @@ by one month.
 | 2019-01-31T23:59:59.999999Z | 115.8 |
 
 ```questdb-sql title="Results in a given month excluding the last 3 days"
-SELECT * FROM scores WHERE ts = '2018-01;-3d';
+SELECT * FROM scores WHERE ts in '2018-01;-3d';
 ```
 
 The range is Jan 2018. The modifier reduces the upper bound (originally 31
@@ -307,21 +336,42 @@ Dec 2018) by 3 days.
 | ...                         | ...   |
 | 2019-01-28T23:59:59.999999Z | 115.8 |
 
-### Explicit range
+### IN with multiple arguments
+
+#### Syntax
+
+`IN` with more than 1 arguments is treated as standard SQL `IN`. It is a shorthand of multiple OR conditions e.g. 
+
+```questdb-sql title="IN list"
+SELECT * FROM scores
+WHERE ts in ('2018-01-01', '2018-01-01T12:00', '2018-01-02');
+```
+is the equivalent of 
+
+```questdb-sql title="IN list equvalent OR"
+SELECT * FROM scores
+WHERE ts = '2018-01-01' or ts = '2018-01-01T12:00' or ts = '2018-01-02');
+```
+
+
+| ts                          | value |
+| --------------------------- | ----- |
+| 2018-01-01T00:00:00.000000Z | 123.4 |
+| 2018-01-01T12:00:00.000000Z | 589.1 |
+| 2018-01-02T00:00:00.000000Z | 131.5 |
+
+### BETWEEN
 
 #### Syntax
 
 For non-standard ranges, users can explicitly specify the target range using the
-`in` operator.
-
-![Flow chart showing the syntax of the WHERE clause with a timestamp range comparison](/img/docs/diagrams/whereTimestampRange.svg)
-
-`lower_bound` and `upper_bound` must be valid timestamps or dates and are
-`inclusive`.
+`between` operator. As with standard SQL both upper and lower bounds of `between` are inclusive 
+also the order of lower and upper bounds is not important so that query 
+`between X and Y` is equievaledn to `between Y and X`.
 
 ```questdb-sql title="Explicit range"
 SELECT * FROM scores
-WHERE ts in('2018-01-01T00:00:23.000000Z' , '2018-01-01T00:00:23.500000Z');
+WHERE ts between '2018-01-01T00:00:23.000000Z' and '2018-01-01T00:00:23.500000Z';
 ```
 
 | ts                          | value |
@@ -329,3 +379,12 @@ WHERE ts in('2018-01-01T00:00:23.000000Z' , '2018-01-01T00:00:23.500000Z');
 | 2018-01-01T00:00:23.000000Z | 123.4 |
 | ...                         | ...   |
 | 2018-01-01T00:00:23.500000Z | 131.5 |
+
+Between can accept non-constant bounds, for example
+
+```questdb-sql title="One year before current date"
+SELECT * FROM scores
+WHERE ts between to_str(now(), 'yyyy-MM-dd') and dateadd('y', -1, to_str(now(), 'yyyy-MM-dd'));
+```
+
+This will return all records one year before beggining of the current date.

--- a/docs/reference/sql/where.md
+++ b/docs/reference/sql/where.md
@@ -206,17 +206,21 @@ SELECT * FROM users WHERE NOT isActive;
 ## Timestamp and date
 
 QuestDB supports both its own timestamp search notation and standard search
-based on inequality. This section describes the use of the
-`timestamp search notation` which is efficient and fast but requires a
-[designated timestamp](/docs/concept/designated-timestamp/). Remember,
-designated timestamp can be applied
-[dynamically](/docs/reference/function/timestamp/#during-a-select-operation).
+based on inequality. This section describes the use of the **timestamp search
+notation** which is efficient and fast but requires a
+[designated timestamp](/docs/concept/designated-timestamp/).
+
+If a table does not have a designated timestamp applied during table creation,
+one may be applied dynamically
+[during a select operation](/docs/reference/function/timestamp/#during-a-select-operation).
 
 ### Native timestamp format
 
-QuestDB automatically recognizes string formatted as ISO timestamp as a timestamp type. Following are valid examples of timestamp strings
+QuestDB automatically recognizes strings formatted as ISO timestamp as a
+`timestamp` type. The following are valid examples of strings parsed as
+`timestamp` types:
 
-| Valid STRING Format              |  Resulting Timestamp        |
+| Valid STRING Format              | Resulting Timestamp         |
 | -------------------------------- | --------------------------- |
 | 2010-01-12T12:35:26.123456+01:30 | 2010-01-12T14:05:26.123456Z |
 | 2010-01-12T12:35:26.123456+01    | 2010-01-12T13:35:26.123456Z |
@@ -240,14 +244,13 @@ QuestDB automatically recognizes string formatted as ISO timestamp as a timestam
 | 2010-01-12 12:35:26              | 2010-01-12T12:35:26.000000Z |
 | 2010-01-12 12:35                 | 2010-01-12T12:35:00.000000Z |
 
-
 ### Exact timestamp
 
 #### Syntax
 
 ![Flow chart showing the syntax of the WHERE clause with a timestamp comparison](/img/docs/diagrams/whereTimestampExact.svg)
 
-```questdb-sql title="Example - Date"
+```questdb-sql title="Timestamp equals date"
 SELECT scores WHERE ts = '2010-01-12T00:02:26.000Z';
 ```
 
@@ -257,7 +260,7 @@ SELECT scores WHERE ts = '2010-01-12T00:02:26.000Z';
 | 2010-01-12T00:02:26.000Z | 3.1   |
 | ...                      | ...   |
 
-```questdb-sql title="Example - Timestamp"
+```questdb-sql title="Timestamp equals timestamp"
 SELECT scores WHERE ts = '2010-01-12T00:02:26.000000Z';
 ```
 
@@ -276,7 +279,7 @@ Return results within a defined range
 ![Flow chart showing the syntax of the WHERE clause with a partial timestamp comparison](/img/docs/diagrams/whereTimestampPartial.svg)
 
 ```questdb-sql title="Results in a given year"
-SELECT * FROM scores WHERE ts in '2018';
+SELECT * FROM scores WHERE ts IN '2018';
 ```
 
 | ts                          | score |
@@ -286,7 +289,7 @@ SELECT * FROM scores WHERE ts in '2018';
 | 2018-12-31T23:59:59.999999Z | 115.8 |
 
 ```questdb-sql title="Results in a given minute"
-SELECT * FROM scores WHERE ts in '2018-05-23T12:15';
+SELECT * FROM scores WHERE ts IN '2018-05-23T12:15';
 ```
 
 | ts                          | score |
@@ -297,7 +300,7 @@ SELECT * FROM scores WHERE ts in '2018-05-23T12:15';
 
 ### Time range with modifier
 
-You can apply a modifier to further customise the range. The algorithm will
+You can apply a modifier to further customize the range. The algorithm will
 calculate the resulting range by modifying the upper bound of the original range
 by the modifier parameter.
 
@@ -311,7 +314,7 @@ by the modifier parameter.
 - A `negative` value reduces the interval.
 
 ```questdb-sql title="Results in a given year and the first month of the next year"
-SELECT * FROM scores WHERE ts in '2018;1M';
+SELECT * FROM scores WHERE ts IN '2018;1M';
 ```
 
 The range is 2018. The modifier extends the upper bound (originally 31 Dec 2018)
@@ -324,7 +327,7 @@ by one month.
 | 2019-01-31T23:59:59.999999Z | 115.8 |
 
 ```questdb-sql title="Results in a given month excluding the last 3 days"
-SELECT * FROM scores WHERE ts in '2018-01;-3d';
+SELECT * FROM scores WHERE ts IN '2018-01;-3d';
 ```
 
 The range is Jan 2018. The modifier reduces the upper bound (originally 31
@@ -340,19 +343,20 @@ Dec 2018) by 3 days.
 
 #### Syntax
 
-`IN` with more than 1 arguments is treated as standard SQL `IN`. It is a shorthand of multiple OR conditions e.g. 
+`IN` with more than 1 argument is treated as standard SQL `IN`. It is a
+shorthand of multiple `OR` conditions, i.e. the following query:
 
 ```questdb-sql title="IN list"
 SELECT * FROM scores
-WHERE ts in ('2018-01-01', '2018-01-01T12:00', '2018-01-02');
+WHERE ts IN ('2018-01-01', '2018-01-01T12:00', '2018-01-02');
 ```
-is the equivalent of 
 
-```questdb-sql title="IN list equvalent OR"
+is equivalent to:
+
+```questdb-sql title="IN list equivalent OR"
 SELECT * FROM scores
 WHERE ts = '2018-01-01' or ts = '2018-01-01T12:00' or ts = '2018-01-02');
 ```
-
 
 | ts                          | value |
 | --------------------------- | ----- |
@@ -365,13 +369,13 @@ WHERE ts = '2018-01-01' or ts = '2018-01-01T12:00' or ts = '2018-01-02');
 #### Syntax
 
 For non-standard ranges, users can explicitly specify the target range using the
-`between` operator. As with standard SQL both upper and lower bounds of `between` are inclusive 
-also the order of lower and upper bounds is not important so that query 
-`between X and Y` is equievaledn to `between Y and X`.
+`BETWEEN` operator. As with standard SQL, both upper and lower bounds of
+`BETWEEN` are inclusive, and the order of lower and upper bounds is not
+important so that `BETWEEN X AND Y` is equivalent to `BETWEEN Y AND X`.
 
 ```questdb-sql title="Explicit range"
 SELECT * FROM scores
-WHERE ts between '2018-01-01T00:00:23.000000Z' and '2018-01-01T00:00:23.500000Z';
+WHERE ts BETWEEN '2018-01-01T00:00:23.000000Z' AND '2018-01-01T00:00:23.500000Z';
 ```
 
 | ts                          | value |
@@ -380,11 +384,11 @@ WHERE ts between '2018-01-01T00:00:23.000000Z' and '2018-01-01T00:00:23.500000Z'
 | ...                         | ...   |
 | 2018-01-01T00:00:23.500000Z | 131.5 |
 
-Between can accept non-constant bounds, for example
+`BETWEEN` can accept non-constant bounds, for example, the following query will
+return all records older than one year before the current date:
 
 ```questdb-sql title="One year before current date"
 SELECT * FROM scores
-WHERE ts between to_str(now(), 'yyyy-MM-dd') and dateadd('y', -1, to_str(now(), 'yyyy-MM-dd'));
+WHERE ts BETWEEN to_str(now(), 'yyyy-MM-dd')
+AND dateadd('y', -1, to_str(now(), 'yyyy-MM-dd'));
 ```
-
-This will return all records one year before beggining of the current date.

--- a/static/img/docs/diagrams/.railroad
+++ b/static/img/docs/diagrams/.railroad
@@ -72,10 +72,10 @@ timestampSearch
   ::= 'WHERE' timestampColumn ( '=' | '>' | '<' | '>=' | '<=' ) "'" timestamp "'"
 
 timestampIntervalSearch
-  ::= 'WHERE' timestampColumn '=' "'" timestamp ';' interval (s | m | h | d | M | y) "'"
+  ::= 'WHERE' timestampColumn 'IN' "'" timestamp ';' interval (s | m | h | d | M | y) "'"
 
 timestampInSearch
-  ::= 'WHERE' timestampColumn 'in' '(' "'timestamp1'" ';' "'timestamp2'" ')'
+  ::= 'WHERE' timestampColumn 'IN' '(' "'timestamp1'" ';' "'timestamp2'" ')'
 
 exactStringOrSymbolSearch
   ::= 'WHERE' column '=' "'" string "'"
@@ -102,10 +102,10 @@ timestampExact
   ::= 'WHERE' column '=' timestamp
 
 timestampPartial
-  ::= 'WHERE' timestampColumn '=' ( 'yyyy' | 'yyyy-MM' | 'YYYY-MM-dd' | 'yyyy-MM-ddThh' | 'yyyy-MM-ddThh:mm' | 'yyyy-MM-ddThh:mm:ss' )
+  ::= 'WHERE' timestampColumn 'IN' ( 'yyyy' | 'yyyy-MM' | 'YYYY-MM-dd' | 'yyyy-MM-ddThh' | 'yyyy-MM-ddThh:mm' | 'yyyy-MM-ddThh:mm:ss' )
 
 timestampExplicitRange
-  ::= 'WHERE' timestamp 'in' '(' lower_bound ',' upper_bound ')'
+  ::= 'WHERE' timestamp 'IN' '(' lower_bound ',' upper_bound ')'
 
 union
   ::= selectStatement ('UNION' 'ALL'? otherSelectStatement)*

--- a/static/img/docs/diagrams/whereTimestampPartial.svg
+++ b/static/img/docs/diagrams/whereTimestampPartial.svg
@@ -37,7 +37,7 @@
     <rect x="119" y="1" width="134" height="32" class="nonterminal"/>
     <text class="nonterminal" x="129" y="21">timestampColumn</text></a><rect x="275" y="3" width="30" height="32" rx="10"/>
     <rect x="273" y="1" width="30" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="283" y="21">=</text>
+    <text class="terminal" x="283" y="21">IN</text>
     <rect x="345" y="3" width="52" height="32" rx="10"/>
     <rect x="343" y="1" width="52" height="32" class="terminal" rx="10"/>
     <text class="terminal" x="353" y="21">yyyy</text>

--- a/static/img/docs/diagrams/whereTimestampPartialModifier.svg
+++ b/static/img/docs/diagrams/whereTimestampPartialModifier.svg
@@ -37,7 +37,7 @@
     <rect x="119" y="1" width="134" height="32" class="nonterminal"/>
     <text class="nonterminal" x="129" y="21">timestampColumn</text></a><rect x="275" y="3" width="30" height="32" rx="10"/>
     <rect x="273" y="1" width="30" height="32" class="terminal" rx="10"/>
-    <text class="terminal" x="283" y="21">=</text>
+    <text class="terminal" x="283" y="21">IN</text>
     <rect x="345" y="3" width="52" height="32" rx="10"/>
     <rect x="343" y="1" width="52" height="32" class="terminal" rx="10"/>
     <text class="terminal" x="353" y="21">yyyy</text>


### PR DESCRIPTION
__Changes:__

### Timestamp string equality
For `WHERE timestamp = '2020-01-01'` is not a range, but a single timestamp of `2020-01-01T00:00:00.000000Z`. The new equivalent with the semantics 'all data for this day' using string equality is

```sql
WHERE timestamp IN '2020-01-01'
```

### lg `<` and gt `>` operators

The string `2020-01-01` does not represent an interval, but a single `TIMESTAMP` data point of `2020-01-01T00:00:00.000000Z`

### `IN` list

To check if data within an interval, use `BETWEEN` i.e.: 

```sql
WHERE timestamp BETWEEN '2020-01-01T00:00:00.000000Z' AND '2020-01-02T00:00:00.000000Z' 
```