### PR TITLE
docs: 6.0.2 - bump QuestDB version, add log, sqrt, bitwise ops, Docker logging, JOIN

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -58,6 +58,19 @@ programming languages.
 - [Authenticate](/docs/develop/authenticate/) via an additional step before
   inserting records using InfluxDB line protocol
 
+## Guides
+
+- [Configuring commit lag of out-of-order (O3) data](/docs/guides/out-of-order-commit-lag/)
+- [InfluxDB line protocol](/docs/guides/influxdb-line-protocol/)
+- [Importing data in bulk via CSV](/docs/guides/importing-data/)
+- [Version 6.0 migration](/docs/guides/v6-migration/)
+
+### Deployment
+
+- [Deploy a QuestDB AMI to AWS using Packer](/docs/guides/aws-packer/)
+- [Run QuestDB on Kubernetes](/docs/guides/kubernetes/)
+- [Google Cloud Platform](/docs/guides/google-cloud-platform/)
+
 ## Third-party tools
 
 This section describes how to integrate QuestDB with third-party tools and
@@ -77,8 +90,6 @@ pages for the following topics:
 
 - [Capacity planning](/docs/operations/capacity-planning/) for configuring
   server settings and system resources for common scenarios and edge cases
-- [Deployment](/docs/operations/deployment/) details with information for
-  running locally, on Kubernetes or the AWS AMI
 - [Data retention](/docs/operations/data-retention/) strategy to delete old data
   and save disk space
 - [Health monitoring](/docs/operations/health-monitoring/) endpoint for
@@ -111,6 +122,7 @@ when starting services:
 ### Functions
 
 - [Aggregation](/docs/reference/function/aggregation/)
+- [Conditional](/docs/reference/function/conditional/)
 - [Date time](/docs/reference/function/date-time/)
 - [Meta](/docs/reference/function/meta/)
 - [Numeric](/docs/reference/function/numeric/)
@@ -120,15 +132,21 @@ when starting services:
 - [Timestamp generator](/docs/reference/function/timestamp-generator/)
 - [Timestamp](/docs/reference/function/timestamp/)
 
+### Operators
+
+- [Bitwise](/docs/reference/operators/bitwise/)
+
 ### SQL
 
 - [SQL Execution order](/docs/reference/sql/datatypes/)
 - [Data types](/docs/reference/sql/datatypes/)
 - [ALTER TABLE ADD COLUMN](/docs/reference/sql/alter-table-add-column/)
 - [ALTER TABLE ALTER COLUMN ADD INDEX](/docs/reference/sql/alter-table-alter-column-add-index/)
+- [ALTER TABLE RENAME COLUMN](/docs/reference/sql/alter-table-rename-column/)
 - [ALTER TABLE DROP COLUMN](/docs/reference/sql/alter-table-drop-column/)
 - [ALTER TABLE ATTACH PARTITION](/docs/reference/sql/alter-table-attach-partition/)
 - [ALTER TABLE DROP PARTITION](/docs/reference/sql/alter-table-drop-partition/)
+- [ALTER TABLE SET PARAM](/docs/reference/sql/alter-table-set-param/)
 - [BACKUP](/docs/reference/sql/backup/)
 - [CASE](/docs/reference/sql/case/)
 - [CAST](/docs/reference/sql/cast/)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -115,7 +115,7 @@ The current directory will then have data persisted to disk:
 
 ```bash title="Current directory contents"
 ├── conf
-│   └── server.conf
+│  └── server.conf
 ├── db
 └── public
 ```
@@ -392,9 +392,9 @@ these methods.
 
 ### Configuration file
 
-Logs may be configured via a dedicated file named `qlog.conf`.
+Logs may be configured via a dedicated file named `log-stdout.conf`.
 
-```shell title="qlog.conf"
+```shell title="log-stdout.conf"
 # list of configured writers
 writers=file,stdout
 
@@ -408,18 +408,52 @@ w.stdout.class=io.questdb.log.LogConsoleWriter
 w.stdout.level=INFO,ERROR
 ```
 
-QuestDB will look for `/qlog.conf` on the classpath unless this name is
+QuestDB will look for `/log-stdout.conf` on the classpath unless this name is
 overridden via a "system" property: `-Dout=/something_else.conf`.
+
+### Docker
+
+When mounting a volume to a Docker container, a logging configuration file may
+be provided in the container located at `/conf/log.conf`. For example, a file
+with the following contents can be created:
+
+```shell title="./conf/log.conf"
+# list of configured writers
+writers=file,stdout,http.min
+
+# file writer
+w.file.class=io.questdb.log.LogFileWriter
+w.file.location=questdb-docker.log
+w.file.level=INFO,ERROR,DEBUG
+
+# stdout
+w.stdout.class=io.questdb.log.LogConsoleWriter
+w.stdout.level=INFO
+
+# min http server, used monitoring
+w.http.min.class=io.questdb.log.LogConsoleWriter
+w.http.min.level=ERROR
+w.http.min.scope=http-min-server
+```
+
+The current directory can be mounted:
+
+```shell title="Mount the current directory to a QuestDB container"
+docker run -p 9000:9000 -v "$(pwd):/root/.questdb/" questdb/questdb
+```
+
+The container logs will be written to disk using the logging level and file name
+provided in the `conf/log.conf` file, in this case in `./questdb-docker.log`.
 
 ### Environment variables
 
-Values in the `qlog.conf` file can be overridden with environment variables. All
-configuration keys must be formatted as described in the
+Values in the `log-stdout.conf` file can be overridden with environment
+variables. All configuration keys must be formatted as described in the
 [environment variables](#environment-variables) section above.
 
 For example, to set logging on `ERROR` level only:
 
-```shell title="Setting log level to ERROR in qlog.conf"
+```shell title="Setting log level to ERROR in log-stdout.conf"
 w.stdout.level=ERROR
 ```
 

--- a/docs/reference/function/numeric.md
+++ b/docs/reference/function/numeric.md
@@ -38,6 +38,28 @@ FROM long_sequence(3);
 | 0   | 0   |
 | 1   | 1   |
 
+## log
+
+`log(value)` return the natural logarithm (**log*e***) of a given number.
+
+**Arguments:**
+
+- `value` is any numeric value.
+
+**Return value:**
+
+Return value type is `double`.
+
+**Examples:**
+
+```questdb-sql
+SELECT log(4.123)
+```
+
+| log          |
+| ------------ |
+| 1.4165810537 |
+
 ## round
 
 `round(value, scale)` returns the **closest** value in the specified scale. It
@@ -212,3 +234,25 @@ FROM dbl;
 | 4.003627053  | 100    | 10     | 5     | 4.1    | 4.01    |
 | 86.91359825  | 100    | 90     | 87    | 87     | 86.92   |
 | 376.3807766  | 400    | 380    | 377   | 376.4  | 376.39  |
+
+## sqrt
+
+`sqrt(value)` return the square root of a given number.
+
+**Arguments:**
+
+- `value` is any numeric value.
+
+**Return value:**
+
+Return value type is `double`.
+
+**Examples:**
+
+```questdb-sql
+SELECT sqrt(4000.32)
+```
+
+| log              |
+| ---------------- |
+| 63.2480829749013 |

--- a/docs/reference/operators/bitwise.md
+++ b/docs/reference/operators/bitwise.md
@@ -1,0 +1,78 @@
+---
+title: Bitwise operators
+sidebar_label: Bitwise
+description: Bitwise operators reference documentation.
+---
+
+This page describes the available operators to assist with performing bitwise
+operations on numeric values.
+
+Precedence of these operators is as follows:
+
+1. `~` NOT
+2. `&` AND
+3. `^` XOR
+4. `|` OR
+
+## ~ NOT
+
+`~` is a unary operation that performs logical negation on each bit. Bits that
+are 0 become 1, and those that are 1 become 0. Expects a value of `long` type.
+
+**Examples:**
+
+```questdb-sql
+SELECT ~1024
+```
+
+| column |
+| ------ |
+| -1025  |
+
+## & AND
+
+`&` is a binary operation that takes two equal-length binary representations and
+performs the logical AND operation on each pair of the corresponding bits.
+Expects values of `long` type.
+
+**Examples:**
+
+```questdb-sql
+SELECT 5 & 3
+```
+
+| column |
+| ------ |
+| 1      |
+
+## ^ XOR
+
+`^` is a binary operation that takes two bit patterns of equal length and
+performs the logical exclusive OR operation on each pair of corresponding bits.
+Expects a value of `long` type.
+
+**Examples:**
+
+```questdb-sql
+SELECT 5 ^ 3
+```
+
+| column |
+| ------ |
+| 6      |
+
+## | OR
+
+`|` is a binary operation that takes two bit patterns of equal length and
+performs the logical inclusive OR operation on each pair of corresponding bits.
+Expects a value of `long` type.
+
+**Examples:**
+
+```questdb-sql
+SELECT 5 ^ 3
+```
+
+| column |
+| ------ |
+| 6      |

--- a/docs/reference/sql/join.md
+++ b/docs/reference/sql/join.md
@@ -31,6 +31,26 @@ use shorthand `ON (column)` clause
 
 :::
 
+## Execution order
+
+Join operations are performed in order of their appearance in a SQL query. The
+following query performs a join on a table with one million rows based on a
+column from a smaller table with one hundred rows:
+
+```questdb-sql
+SELECT * FROM 1_million_rows
+INNER JOIN 1_hundred_rows
+ON 1_million_rows.customer_id = 1_hundred_rows.referral_id;
+```
+
+The performance of this query can be improved by rewriting the query as follows:
+
+```questdb-sql
+SELECT * FROM 1_hundred_rows
+INNER JOIN 1_million_rows
+ON 1_million_rows.referral_id = 1_hundred_rows.customer_id;
+```
+
 ## Implicit joins
 
 It is possible to join two tables using the following syntax:
@@ -68,7 +88,7 @@ table matching an `id` in the `movies` table.
 ```questdb-sql title="INNER JOIN ON"
 SELECT movieId a, title, avg(rating)
 FROM ratings
-INNER JOIN (select movieId id, title from movies)
+INNER JOIN (SELECT movieId id, title FROM movies)
 ON ratings.movieId = id;
 ```
 
@@ -78,7 +98,7 @@ need to be specified.
 ```questdb-sql title="Dropping INNER"
 SELECT movieId a, title, avg(rating)
 FROM ratings
-JOIN (select movieId id, title from movies)
+JOIN (SELECT movieId id, title FROM movies)
 ON ratings.movieId = id;
 ```
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,7 +21,7 @@ const customFields = {
   slackUrl: `https://slack.${domain}`,
   stackoverflowUrl: "https://stackoverflow.com/questions/tagged/questdb",
   twitterUrl: "https://twitter.com/questdb",
-  version: "6.0.1",
+  version: "6.0.2",
   videosUrl: "https://www.youtube.com/channel/UChqKEmOyiD9c6QFx2mjKwiA",
 }
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -138,6 +138,11 @@ module.exports = {
         },
         {
           type: "category",
+          label: "Operators",
+          items: ["reference/operators/bitwise"],
+        },
+        {
+          type: "category",
           label: "SQL",
           items: [
             "concept/sql-execution-order",


### PR DESCRIPTION
__Additions:__
* `sqrt()` function for calculating the square root of a number
* `log()` function for calculating the natural logarithm of a number
* bitwise operators (`~` NOT , `^` XOR , `|` OR, `&` AND)
* details for Docker logging configuration, mounting local `conf/log.conf` file to a container
* `JOIN` execution order hints

__Fixes:__
* `qlog.conf` typo fixed to `/log-stdout.conf`