### PR TITLE
chore: sendall(), 'timestamp IN'

### DIFF
--- a/docs/develop/insert-data.md
+++ b/docs/develop/insert-data.md
@@ -221,11 +221,11 @@ sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 try:
   sock.connect((HOST, PORT))
   # Single record insert
-  sock.send(('trades,name=client_timestamp value=12.4 %d\n' %(time.time_ns())).encode())
+  sock.sendall(('trades,name=client_timestamp value=12.4 %d\n' %(time.time_ns())).encode())
   # Omitting the timestamp allows the server to assign one
-  sock.send(('trades,name=server_timestamp value=12.4\n').encode())
+  sock.sendall(('trades,name=server_timestamp value=12.4\n').encode())
   # Streams of readings must be newline-delimited
-  sock.send(('trades,name=ilp_stream_1 value=12.4\ntrades,name=ilp_stream_2 value=11.4\n').encode())
+  sock.sendall(('trades,name=ilp_stream_1 value=12.4\ntrades,name=ilp_stream_2 value=11.4\n').encode())
 
 except socket.error as e:
   print("Got error: %s" % (e))

--- a/docs/guides/influxdb-line-protocol.md
+++ b/docs/guides/influxdb-line-protocol.md
@@ -219,11 +219,11 @@ sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 try:
   sock.connect(('localhost', 9009))
   # Single record insert
-  sock.send(('trades,name=client_timestamp value=12.4 %d\n' %(time.time_ns())).encode())
+  sock.sendall(('trades,name=client_timestamp value=12.4 %d\n' %(time.time_ns())).encode())
   # Omitting the timestamp allows the server to assign one
-  sock.send(('trades,name=server_timestamp value=12.4\n').encode())
+  sock.sendall(('trades,name=server_timestamp value=12.4\n').encode())
   # Streams of readings must be newline-delimited
-  sock.send(('trades,name=ilp_stream_1 value=12.4\ntrades,name=ilp_stream_2 value=11.4\n').encode())
+  sock.sendall(('trades,name=ilp_stream_1 value=12.4\ntrades,name=ilp_stream_2 value=11.4\n').encode())
 
 except socket.error as e:
   print("Got error: %s" % (e))

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -644,7 +644,7 @@ const getTopByIndex = (m: number[], index: 1 | 2 | 3 | 4): number => {
 
 const searchQuery = `SELECT timestamp, tempC
 FROM sensors
-WHERE timestamp = '2020-06-14;1M';`
+WHERE timestamp IN '2021-05-14;1M';`
 
 const sliceQuery = `SELECT timestamp, avg(tempC)
 FROM sensors


### PR DESCRIPTION
__Minor corrections:__
* `send()` in ILP Python example should use `sendall()`
* `timestamp =` to `timestamp IN` on index
