### PR TITLE
chore: bump sql grammar to 1.0.7 for syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@docusaurus/module-type-aliases": "2.0.0-alpha.75",
     "@docusaurus/plugin-pwa": "2.0.0-alpha.75",
     "@docusaurus/preset-classic": "2.0.0-alpha.75",
-    "@questdb/sql-grammar": "1.0.5",
+    "@questdb/sql-grammar": "1.0.7",
     "@tsconfig/docusaurus": "1.0.2",
     "@types/react": "16.9.56",
     "@types/react-helmet": "6.1.0",

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -29,7 +29,7 @@ const prismIncludeLanguages = (PrismObject) => {
         greedy: true,
         lookbehind: true,
       },
-      function: new RegExp(`\\b(?:${functions.join("|")})(?=\\s*\\()`, "i"),
+      function: new RegExp(`\\b(?:${functions.join("|")})((?=\\s*\\()|\\b)`, "i"),
       keyword: new RegExp(`\\b(?:${keywords.join("|")})\\b`, "i"),
       boolean: new RegExp(`\\b(?:${constants.join("|")})\\b`, "i"),
       number: /\b0x[\da-f]+\b|\b\d+\.?\d*|\B\.\d+\b/i,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2523,10 +2523,10 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.12.tgz#431ec342a7195622f86688bbda82e3166ce8cb28"
   integrity sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ==
 
-"@questdb/sql-grammar@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@questdb/sql-grammar/-/sql-grammar-1.0.5.tgz#9001db1e9863d5c304b5ebde24114e33fbeeaa61"
-  integrity sha512-RVpUSfhPpjjQ4h5k/tV8Ai8HTj0pWrcpCuklPUjO32o/xN+lTood1r43a1Bzk5ngad6+heVlnmSiG/XGGwMOxw==
+"@questdb/sql-grammar@1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@questdb/sql-grammar/-/sql-grammar-1.0.7.tgz#2f984339cd42bb22012f5e7da12541fd45ef6e0d"
+  integrity sha512-YycmGd6qouWntvEPx1XhY2xnsSZ2BZq930BuK66HlKgjUtlQzEWp9aOaXAUtN0YUqxOdYAIU/y+ZHfzdx4E1yw==
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.0"


### PR DESCRIPTION
__Updates:__

Ran the following to upgrade SQL grammar to latest (1.0.7):

```bash
yarn upgrade @questdb/sql-grammar@1.0.7
```

This is evident as the `BETWEEN` keyword is not highlighted on master, see https://questdb.io/docs/reference/sql/where/#between

__Fixes:__
Updated Prism syntax highlighting on the docs to make way for the use of grammar used in questdb/sql-grammar which is passed as functions (DAY, MONTH, YEAR) - see https://github.com/questdb/sql-grammar/blob/master/src/functions.ts.
The regex used to match this on our docs expects parens following the function name. Now relaxed this to allow for grammar which ends in word boundary, i.e.:

```sql
--- matches
max()
MONTH

--- does not match
maxUncommitted...
```