### PR TITLE
chore: minor typo fixes, correct case

### DIFF
--- a/docs/reference/sql/case.md
+++ b/docs/reference/sql/case.md
@@ -28,13 +28,13 @@ Assume the following data
 | Jack  | 8   |
 
 ```questdb-sql title="CASE with ELSE"
-select
+SELECT
 name,
-case
-    when age > 18 then 'major'
-    else 'minor'
-end
-from table
+CASE
+    WHEN age > 18 THEN 'major'
+    ELSE 'minor'
+END
+FROM my_table
 ```
 
 Result
@@ -47,12 +47,12 @@ Result
 | Jack  | minor |
 
 ```questdb-sql title="CASE without ELSE"
-select
-Name,
-case
-    when age > 18 then 'major'
-end
-from table
+SELECT
+name,
+CASE
+    WHEN age > 18 THEN 'major'
+END
+FROM my_table
 ```
 
 Result

--- a/docs/reference/sql/fill.md
+++ b/docs/reference/sql/fill.md
@@ -52,8 +52,8 @@ third hour (`2021-01-01T13`):
 The following query returns the minimum, maximum and average price per hour:
 
 ```questdb-sql
-SELECT ts, min(price) min, max(price) max, avg(price) avg
-FROM PRICES
+SELECT ts, min(price) min, max(price) max, avg(price) average
+FROM prices
 SAMPLE BY 1h;
 ```
 
@@ -78,8 +78,8 @@ Based on this example, a `FILL` strategy can be employed which fills with the
 previous value using `PREV`:
 
 ```questdb-sql
-SELECT ts, min(price) min, max(price) max, avg(price) avg
-FROM PRICES
+SELECT ts, min(price) min, max(price) max, avg(price) average
+FROM prices
 SAMPLE BY 1h
 FILL(PREV);
 ```
@@ -98,8 +98,8 @@ using the `FILL` keyword:
 This query demonstrates using a `LINEAR` value for interpolation:
 
 ```questdb-sql
-SELECT ts, min(price) min, avg(price) avg
-FROM PRICES`
+SELECT ts, min(price) min, avg(price) average
+FROM prices
 SAMPLE BY 1h
 FILL(LINEAR);
 ```
@@ -119,8 +119,8 @@ value is used as a `fillOption`, a value must be specified for each aggregate
 column:
 
 ```questdb-sql
-SELECT ts, min(price) min, avg(price) avg
-FROM PRICES`
+SELECT ts, min(price) min, avg(price) average
+FROM prices
 SAMPLE BY 1h
 FILL(100.5, 10, 1);
 ```
@@ -138,8 +138,8 @@ The results of this query look like the following:
 This query demonstrates using `NULL` as a `fillOption`:
 
 ```questdb-sql
-SELECT ts, min(price) min, avg(price) avg
-FROM PRICES`
+SELECT ts, min(price) min, avg(price) average
+FROM prices
 SAMPLE BY 1h
 FILL(NULL);
 ```


### PR DESCRIPTION
* Use uppercase for SQL keywords, correct typos in examples