### PR TITLE
docs: add first(), last(), change 'lag' to 'commitLag'

### DIFF
--- a/docs/guides/importing-data.md
+++ b/docs/guides/importing-data.md
@@ -93,16 +93,16 @@ For more information on the `/imp` entry point, refer to the
 
 ## Large datasets with out-of-order data
 
-Using the `lag` and `batch` size parameters during `INSERT AS SELECT` statements
-is a convenient strategy to load and order large datasets from CSV in bulk when
-they contain out-of-order data.
+Using the `commitLag` and `batch` size parameters during `INSERT AS SELECT`
+statements is a convenient strategy to load and order large datasets from CSV in
+bulk when they contain out-of-order data.
 
 The batch size specifies how many records to attempt to bulk insert at one time
 and the **lag** allows for specifying the expected lateness of out-of-order
 timestamp values (in microseconds):
 
 ```questdb-sql
-INSERT batch 100000 lag 180000000 INTO my_table
+INSERT batch 100000 commitLag 180s INTO my_table
 SELECT * FROM unordered_table
 ```
 
@@ -142,7 +142,7 @@ ordered table may be created using the following steps:
    and `batch` size:
 
    ```questdb-sql
-   INSERT batch 100000 lag 180000000 INTO weather
+   INSERT batch 100000 commitLag 180s INTO weather
    SELECT
      cast(timestamp AS timestamp) timestamp,
      windDir,

--- a/docs/guides/out-of-order-commit-lag.md
+++ b/docs/guides/out-of-order-commit-lag.md
@@ -160,7 +160,7 @@ docker run -p 9000:9000 \
  questdb/questdb
 ```
 
-### Per-table lag and maximum uncommitted rows
+### Per-table commit lag and maximum uncommitted rows
 
 It's possible to set out-of-order values per table when creating a new table as
 part of the `PARTITION BY` clause. Configuration is passed using the `WITH`
@@ -200,7 +200,7 @@ ALTER TABLE my_table SET PARAM commitLag = 20s
 For more information on checking table metadata, see the
 [meta functions](/docs/reference/function/meta/) documentation page.
 
-### INSERT lag and batch size
+### INSERT commit lag and batch size
 
 The `INSERT` keyword may be passed parameters for handling the expected _lag_ of
 out-of-order records and a _batch_ size for the number of rows to process and
@@ -208,7 +208,7 @@ insert at once. The following query shows an `INSERT AS SELECT` operation with
 lag and batch size applied:
 
 ```questdb-sql
-INSERT batch 100000 lag 180000000 INTO trades
+INSERT batch 100000 commitLag 180s INTO trades
 SELECT ts, instrument, quantity, price
 FROM unordered_trades
 ```

--- a/docs/guides/out-of-order-commit-lag.md
+++ b/docs/guides/out-of-order-commit-lag.md
@@ -197,7 +197,9 @@ and
 ALTER TABLE my_table SET PARAM commitLag = 20s
 ```
 
-For more information on checking table metadata, see the
+For more information on setting table parameters via SQL, see the
+[SET PARAM](/docs/reference/sql/alter-table-set-param/) reference. Additional
+details on checking table metadata is described in the
 [meta functions](/docs/reference/function/meta/) documentation page.
 
 ### INSERT commit lag and batch size
@@ -212,6 +214,9 @@ INSERT batch 100000 commitLag 180s INTO trades
 SELECT ts, instrument, quantity, price
 FROM unordered_trades
 ```
+
+For more information on using `INSERT` statements with parameters, see the
+[INSERT parameters](/docs/reference/sql/insert/#parameters) documentation.
 
 :::info
 

--- a/docs/reference/function/aggregation.md
+++ b/docs/reference/function/aggregation.md
@@ -123,6 +123,35 @@ SELECT payment_type, count_distinct(counterparty) FROM transactions;
 
 :::
 
+## first
+
+`first(SYMBOL)` - returns the first value of a `SYMBOL` column.
+
+**Return value:**
+
+Return value type is `string`.
+
+**Examples:**
+
+Given a table with the following contents:
+
+| device_id  | temperature | ts                          |
+| ---------- | ----------- | --------------------------- |
+| arduino-01 | 12          | 2021-06-02T14:33:19.970258Z |
+| arduino-02 | 10          | 2021-06-02T14:33:21.703934Z |
+| arduino-03 | 18          | 2021-06-02T14:33:23.707013Z |
+
+The following query returns the first symbol value for the `device_id` column
+which is of `SYMBOL` type:
+
+```questdb-sql
+SELECT first(device_id) FROM sensors;
+```
+
+| first      |
+| ---------- |
+| arduino-01 |
+
 ## haversine_dist_deg
 
 `haversine_dist_deg(lat, lon, ts)` - calculates the traveled distance for a
@@ -171,6 +200,35 @@ FROM (SELECT rnd_double() a FROM long_sequence(100));
 | ksum              |
 | ----------------- |
 | 52.79143968514029 |
+
+## last
+
+`last(SYMBOL)` - returns the last value of a `SYMBOL` column.
+
+**Return value:**
+
+Return value type is `string`.
+
+**Examples:**
+
+Given a table with the following contents:
+
+| device_id  | temperature | ts                          |
+| ---------- | ----------- | --------------------------- |
+| arduino-01 | 12          | 2021-06-02T14:33:19.970258Z |
+| arduino-02 | 10          | 2021-06-02T14:33:21.703934Z |
+| arduino-03 | 18          | 2021-06-02T14:33:23.707013Z |
+
+The following query returns the last symbol value for the `device_id` column
+which is of `SYMBOL` type:
+
+```questdb-sql
+SELECT last(device_id) FROM sensors;
+```
+
+| last       |
+| ---------- |
+| arduino-03 |
 
 ## max
 

--- a/docs/reference/function/meta.md
+++ b/docs/reference/function/meta.md
@@ -71,6 +71,12 @@ SELECT type, count() FROM table_columns('my_table');
 
 `tables()` returns all tables in the database including table metadata.
 
+:::info
+
+`commitLag` is returned in _microseconds_
+
+:::
+
 **Arguments:**
 
 - `tables()` does not require arguments.

--- a/docs/reference/sql/alter-table-set-param.md
+++ b/docs/reference/sql/alter-table-set-param.md
@@ -23,13 +23,50 @@ functions which are described in the
 ![Flow chart showing the syntax of the ALTER TABLE keyword](/img/docs/diagrams/alterTable.svg)
 ![Flow chart showing the syntax of the ALTER TABLE RENAME COLUMN keywords](/img/docs/diagrams/alterTableSetParam.svg)
 
+The following two sections describe table parameters relating to out-of-order
+ingestion. For context on commit lag and max uncommitted rows, see the guide for
+[configuring commit lag of out-of-order data](/docs/guides/out-of-order-commit-lag/).
+
+### commitLag
+
+`commitLag` allows for specifying the expected maximum _lag_ of late-arriving
+records when ingesting out-of-order data. The purpose of specifying a commit lag
+per table is to reduce the occurrences of resource-intensive commits when
+ingesting out-of-order data. Incoming records will be kept in memory until for
+the duration specified in _lag_, then all records up to the boundary will be
+ordered and committed.
+
+`commitLag` expects a value with a modifier to specify the unit of time for the
+value:
+
+| unit | description  |
+| ---- | ------------ |
+| us   | microseconds |
+| s    | seconds      |
+| m    | minutes      |
+| h    | hours        |
+| d    | days         |
+
+To specify `commitLag` value to 20 seconds:
+
+```questdb-sql
+ALTER TABLE my_table SET PARAM commitLag = 20s
+```
+
+### maxUncommittedRows
+
+`maxUncommittedRows` allows for specifying the maximum number of uncommitted
+rows per-table to keep in memory before triggering a commit. The purpose of
+specifying maximum uncommitted rows per table is to reduce the occurrences of
+resource-intensive commits when ingesting out-of-order data.
+
 ## Example
 
 The values for **maximum uncommitted rows** and a time range for **commit lag**
 can changed per each table with the following SQL:
 
 ```questdb-sql title="Altering out-of-order parameters via SQL"
-ALTER TABLE my_table SET PARAM maxUncommittedRows=10000
+ALTER TABLE my_table SET PARAM maxUncommittedRows = 10000
 ALTER TABLE my_table SET PARAM commitLag=20s
 ```
 

--- a/docs/reference/sql/alter-table-set-param.md
+++ b/docs/reference/sql/alter-table-set-param.md
@@ -67,7 +67,7 @@ can changed per each table with the following SQL:
 
 ```questdb-sql title="Altering out-of-order parameters via SQL"
 ALTER TABLE my_table SET PARAM maxUncommittedRows = 10000
-ALTER TABLE my_table SET PARAM commitLag=20s
+ALTER TABLE my_table SET PARAM commitLag = 20s
 ```
 
 Checking the values per-table may be done using the `tables()` function:
@@ -79,6 +79,12 @@ select id, name, maxUncommittedRows, commitLag from tables();
 | id  | name     | maxUncommittedRows | commitLag |
 | --- | -------- | ------------------ | --------- |
 | 1   | my_table | 10000              | 20000000  |
+
+:::info
+
+`commitLag` is returned in _microseconds_
+
+:::
 
 For more details on retrieving table and column information, see the
 [meta functions documentation](/docs/reference/function/meta/).

--- a/docs/reference/sql/create-table.md
+++ b/docs/reference/sql/create-table.md
@@ -179,7 +179,16 @@ may be set during table creation using the `WITH` keyword. The following two
 parameters may be applied:
 
 - `maxUncommittedRows` - equivalent to `cairo.max.uncommitted.rows`
-- `commitLag` - equivalent to `cairo.commit.lag`
+- `commitLag` - equivalent to `cairo.commit.lag` expects a value with a modifier
+  to specify the unit of time for the value:
+
+  | unit | description  |
+  | ---- | ------------ |
+  | us   | microseconds |
+  | s    | seconds      |
+  | m    | minutes      |
+  | h    | hours        |
+  | d    | days         |
 
 For more information on commit lag and the maximum uncommitted rows, see the
 guide for [out-of-order commits](/docs/guides/out-of-order-commit-lag/).

--- a/docs/reference/sql/create-table.md
+++ b/docs/reference/sql/create-table.md
@@ -255,7 +255,7 @@ count, or the _lag_ boundary is met:
 
 ```questdb-sql
 CREATE TABLE my_table (timestamp TIMESTAMP) timestamp(timestamp)
-PARTITION BY DAY WITH maxUncommittedRows=250000, commitLag=240s
+PARTITION BY DAY WITH maxUncommittedRows=250000, commitLag = 240s
 ```
 
 For more information on out-of-order lag and uncommitted rows, see the

--- a/docs/reference/sql/insert.md
+++ b/docs/reference/sql/insert.md
@@ -17,8 +17,17 @@ inserting out-of-order records into an ordered dataset:
 
 - `batch` expects a `batchCount` (integer) value how many records to process at
   any one time
-- `lag` expects a `lagAmount` (integer) value in **microseconds** which
-  specifies the expected lateness of out-of-order records
+- `commitLag` expects a `lagAmount` with a modifier to specify the unit of time
+  for the value (i.e. `20s` for 20 seconds). The following table describes the
+  units that may be passed:
+
+  | unit | description  |
+  | ---- | ------------ |
+  | us   | microseconds |
+  | s    | seconds      |
+  | m    | minutes      |
+  | h    | hours        |
+  | d    | days         |
 
 ## Examples
 
@@ -65,19 +74,23 @@ INSERT INTO confirmed_trades
 ```
 
 Inserting out-of-order data into an ordered dataset may be optimized using
-`batch` and `lag` parameters:
+`batch` and `commitLag` parameters:
 
 ```questdb-sql title="Insert as select with lag and batch size"
-INSERT batch 100000 lag 180000000 INTO trades
+INSERT batch 100000 commitLag 180s INTO trades
 SELECT ts, instrument, quantity, price
 FROM unordered_trades
 ```
 
 :::info
 
-Hints and an example workflow using `INSERT AS SELECT` for bulk CSV import of
-out-of-order data can be found on the
-[importing data via CSV](/docs/guides/importing-data/#large-datasets-with-out-of-order-data)
-documentation.
+- More details on ingesting out-of-order data with context on _lag_ and
+  uncommitted record count see the guide
+  for +[configuring commit lag of out-of-order data](/docs/guides/out-of-order-commit-lag/)
+
+- Hints and an example workflow using `INSERT AS SELECT` for bulk CSV import of
+  out-of-order data can be found on the
+  [importing data via CSV](/docs/guides/importing-data/#large-datasets-with-out-of-order-data)
+  documentation.
 
 :::

--- a/docs/reference/sql/insert.md
+++ b/docs/reference/sql/insert.md
@@ -85,8 +85,8 @@ FROM unordered_trades
 :::info
 
 - More details on ingesting out-of-order data with context on _lag_ and
-  uncommitted record count see the guide
-  for +[configuring commit lag of out-of-order data](/docs/guides/out-of-order-commit-lag/)
+  uncommitted record count see the guide for
+  [configuring commit lag of out-of-order data](/docs/guides/out-of-order-commit-lag/)
 
 - Hints and an example workflow using `INSERT AS SELECT` for bulk CSV import of
   out-of-order data can be found on the

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -29,7 +29,10 @@ const prismIncludeLanguages = (PrismObject) => {
         greedy: true,
         lookbehind: true,
       },
-      function: new RegExp(`\\b(?:${functions.join("|")})((?=\\s*\\()|\\b)`, "i"),
+      function: new RegExp(
+        `\\b(?:${functions.join("|")})((?=\\s*\\()|\\b)`,
+        "i",
+      ),
       keyword: new RegExp(`\\b(?:${keywords.join("|")})\\b`, "i"),
       boolean: new RegExp(`\\b(?:${constants.join("|")})\\b`, "i"),
       number: /\b0x[\da-f]+\b|\b\d+\.?\d*|\B\.\d+\b/i,

--- a/static/img/docs/diagrams/.railroad
+++ b/static/img/docs/diagrams/.railroad
@@ -33,8 +33,7 @@ indexCapacityDef
   ::= 'capacity' valueBlockSize
 
 insertInto
-  ::= 'INSERT' (batch batchCount lag lagAmount)? 'INTO' tableName (('('columnName (',' columnName)*) ')')? ('VALUES' '(' value (',' value)* ')' | 'SELECT' queryDef )
-
+  ::= 'INSERT' ('batch' batchCount 'commitLag' n ( 'us' | 's' | 'm' | 'h' | 'd' ))? 'INTO' tableName (('('columnName (',' columnName)*) ')')? ('VALUES' '(' value (',' value)* ')' | 'SELECT' queryDef )
 Backup
   ::= 'BACKUP' ( 'TABLE' tableName ( ',' tableName )* | 'DATABASE' ) ';'
 
@@ -150,4 +149,4 @@ attachPartition
  ::= 'ATTACH' 'PARTITION' 'LIST' partitionName (',' partitionName)*
 
 setParam
- ::= 'SET' 'PARAM' ( 'commitLag' | 'maxUncommittedRows' ) value
+ ::= 'SET' 'PARAM' ( 'maxUncommittedRows' '=' n | 'commitLag' '=' n ( 'us' | 's' | 'm' | 'h' | 'd' ))

--- a/static/img/docs/diagrams/.railroad
+++ b/static/img/docs/diagrams/.railroad
@@ -47,7 +47,7 @@ CreateTableTimestamp
   ::= 'CREATE' someCreateTableStatement 'timestamp' '(' columnName ')'
 
 createTableWithParams
-         ::= 'WITH' maxUncommittedRows '=' rowCount ',' commitLag '=' lag
+         ::= 'WITH' 'maxUncommittedRows' '=' rowCount ',' 'commitLag' '=' n ( 'us' | 's' | 'm' | 'h' | 'd' )
 
 dynamicTimestamp
   ::= 'SELECT' someSelectStatement 'timestamp' '(' columnName ')'

--- a/static/img/docs/diagrams/alterTableSetParam.svg
+++ b/static/img/docs/diagrams/alterTableSetParam.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="605" height="80">
+<svg xmlns="http://www.w3.org/2000/svg" width="605" height="260">
     <defs>
         <style type="text/css">
             @namespace "http://www.w3.org/2000/svg";
@@ -36,14 +36,37 @@
          <rect x="95" y="3" width="68" height="32" rx="10"/>
          <rect x="93" y="1" width="68" height="32" class="terminal" rx="10"/>
          <text class="terminal" x="103" y="21">PARAM</text>
-         <rect x="203" y="3" width="160" height="32" rx="10"/>
-         <rect x="201" y="1" width="160" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="211" y="21">commitLag</text>
-         <rect x="203" y="47" width="190" height="32" rx="10"/>
-         <rect x="201" y="45" width="190" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="211" y="65">maxUncommittedRows</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#value" xlink:title="value">
-            <rect x="433" y="3" width="54" height="32"/>
-            <rect x="431" y="1" width="54" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="441" y="21">value</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m44 0 h10 m0 0 h10 m68 0 h10 m20 0 h10 m160 0 h10 m0 0 h30 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v24 m230 0 v-24 m-230 24 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m190 0 h10 m20 -44 h10 m54 0 h10 m3 0 h-3"/>
-         <polygon points="505 17 513 13 513 21"/>
-         <polygon points="505 17 497 13 497 21"/></svg>
+         <rect x="203" y="3" width="176" height="32" rx="10"/>
+         <rect x="201" y="1" width="176" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="211" y="21">maxUncommittedRows</text>
+         <rect x="399" y="3" width="30" height="32" rx="10"/>
+         <rect x="397" y="1" width="30" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="407" y="21">=</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#n" xlink:title="n">
+            <rect x="449" y="3" width="28" height="32"/>
+            <rect x="447" y="1" width="28" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="457" y="21">n</text></a><rect x="203" y="47" width="94" height="32" rx="10"/>
+         <rect x="201" y="45" width="94" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="211" y="65">commitLag</text>
+         <rect x="317" y="47" width="30" height="32" rx="10"/>
+         <rect x="315" y="45" width="30" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="325" y="65">=</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#n" xlink:title="n">
+            <rect x="367" y="47" width="28" height="32"/>
+            <rect x="365" y="45" width="28" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="375" y="65">n</text></a><rect x="435" y="47" width="36" height="32" rx="10"/>
+         <rect x="433" y="45" width="36" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="443" y="65">us</text>
+         <rect x="435" y="91" width="26" height="32" rx="10"/>
+         <rect x="433" y="89" width="26" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="443" y="109">s</text>
+         <rect x="435" y="135" width="32" height="32" rx="10"/>
+         <rect x="433" y="133" width="32" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="443" y="153">m</text>
+         <rect x="435" y="179" width="28" height="32" rx="10"/>
+         <rect x="433" y="177" width="28" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="443" y="197">h</text>
+         <rect x="435" y="223" width="28" height="32" rx="10"/>
+         <rect x="433" y="221" width="28" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="443" y="241">d</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m44 0 h10 m0 0 h10 m68 0 h10 m20 0 h10 m176 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m28 0 h10 m0 0 h14 m-328 0 h20 m308 0 h20 m-348 0 q10 0 10 10 m328 0 q0 -10 10 -10 m-338 10 v24 m328 0 v-24 m-328 24 q0 10 10 10 m308 0 q10 0 10 -10 m-318 10 h10 m94 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m28 0 h10 m20 0 h10 m36 0 h10 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m26 0 h10 m0 0 h10 m-66 -10 v20 m76 0 v-20 m-76 20 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m32 0 h10 m0 0 h4 m-66 -10 v20 m76 0 v-20 m-76 20 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m28 0 h10 m0 0 h8 m-66 -10 v20 m76 0 v-20 m-76 20 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m28 0 h10 m0 0 h8 m43 -220 h-3"/>
+         <polygon points="529 17 537 13 537 21"/>
+         <polygon points="529 17 521 13 521 21"/></svg>

--- a/static/img/docs/diagrams/createTableWithCommitParam.svg
+++ b/static/img/docs/diagrams/createTableWithCommitParam.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="741" height="49">
+<svg xmlns="http://www.w3.org/2000/svg" width="841" height="249">
     <defs>
         <style type="text/css">
             @namespace "http://www.w3.org/2000/svg";
@@ -32,24 +32,41 @@
          <polygon points="17 17 9 13 9 21"/>
          <rect x="31" y="3" width="58" height="32" rx="10"/>
          <rect x="29" y="1" width="58" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="39" y="21">WITH</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#maxUncommittedRows" xlink:title="maxUncommittedRows">
-            <rect x="109" y="3" width="164" height="32"/>
-            <rect x="107" y="1" width="164" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="117" y="21">maxUncommittedRows</text></a><rect x="293" y="3" width="30" height="32" rx="10"/>
-         <rect x="291" y="1" width="30" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="301" y="21">=</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#rowCount" xlink:title="rowCount">
-            <rect x="343" y="3" width="80" height="32"/>
-            <rect x="341" y="1" width="80" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="351" y="21">rowCount</text></a><rect x="443" y="3" width="24" height="32" rx="10"/>
-         <rect x="441" y="1" width="24" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="451" y="21">,</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#commitLag" xlink:title="commitLag">
-            <rect x="487" y="3" width="88" height="32"/>
-            <rect x="485" y="1" width="88" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="495" y="21">commitLag</text></a><rect x="595" y="3" width="30" height="32" rx="10"/>
-         <rect x="593" y="1" width="30" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="603" y="21">=</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#lag" xlink:title="lag">
-            <rect x="645" y="3" width="38" height="32"/>
-            <rect x="643" y="1" width="38" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="653" y="21">lag</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m164 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m88 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m38 0 h10 m3 0 h-3"/>
-         <polygon points="701 17 709 13 709 21"/>
-         <polygon points="701 17 693 13 693 21"/></svg>
+         <text class="terminal" x="39" y="21">WITH</text>
+         <rect x="109" y="3" width="176" height="32" rx="10"/>
+         <rect x="107" y="1" width="176" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="117" y="21">maxUncommittedRows</text>
+         <rect x="305" y="3" width="30" height="32" rx="10"/>
+         <rect x="303" y="1" width="30" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="313" y="21">=</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#rowCount" xlink:title="rowCount">
+            <rect x="355" y="3" width="80" height="32"/>
+            <rect x="353" y="1" width="80" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="363" y="21">rowCount</text></a><rect x="455" y="3" width="24" height="32" rx="10"/>
+         <rect x="453" y="1" width="24" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="463" y="21">,</text>
+         <rect x="499" y="3" width="94" height="32" rx="10"/>
+         <rect x="497" y="1" width="94" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="507" y="21">commitLag</text>
+         <rect x="613" y="3" width="30" height="32" rx="10"/>
+         <rect x="611" y="1" width="30" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="621" y="21">=</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#n" xlink:title="n">
+            <rect x="663" y="3" width="28" height="32"/>
+            <rect x="661" y="1" width="28" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="671" y="21">n</text></a><rect x="731" y="3" width="36" height="32" rx="10"/>
+         <rect x="729" y="1" width="36" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="739" y="21">us</text>
+         <rect x="731" y="47" width="26" height="32" rx="10"/>
+         <rect x="729" y="45" width="26" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="739" y="65">s</text>
+         <rect x="731" y="91" width="32" height="32" rx="10"/>
+         <rect x="729" y="89" width="32" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="739" y="109">m</text>
+         <rect x="731" y="135" width="28" height="32" rx="10"/>
+         <rect x="729" y="133" width="28" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="739" y="153">h</text>
+         <rect x="731" y="179" width="28" height="32" rx="10"/>
+         <rect x="729" y="177" width="28" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="739" y="197">d</text>
+         <svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m176 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m28 0 h10 m20 0 h10 m36 0 h10 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m26 0 h10 m0 0 h10 m-66 -10 v20 m76 0 v-20 m-76 20 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m32 0 h10 m0 0 h4 m-66 -10 v20 m76 0 v-20 m-76 20 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m28 0 h10 m0 0 h8 m-66 -10 v20 m76 0 v-20 m-76 20 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m28 0 h10 m0 0 h8 m23 -176 h-3"/>
+         <polygon points="805 17 813 13 813 21"/>
+         <polygon points="805 17 797 13 797 21"/></svg>

--- a/static/img/docs/diagrams/insert.svg
+++ b/static/img/docs/diagrams/insert.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="980" height="125">
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="425">
         <defs>
             <style type="text/css">
                 @namespace "http://www.w3.org/2000/svg";
@@ -28,57 +28,71 @@
                 polygon.regexp        {fill: #C7ECFF; stroke: #038cbc;}
             </style>
         </defs>
-        <polygon points="9 61 1 57 1 65"/>
-         <polygon points="17 61 9 57 9 65"/>
-         <rect x="31" y="47" width="70" height="32" rx="10"/>
-         <rect x="29" y="45" width="70" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="39" y="65">INSERT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#batch" xlink:title="batch">
-            <rect x="141" y="79" width="54" height="32"/>
-            <rect x="139" y="77" width="54" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="149" y="97">batch</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#batchCount" xlink:title="batchCount">
-            <rect x="215" y="79" width="92" height="32"/>
-            <rect x="213" y="77" width="92" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="223" y="97">batchCount</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#lag" xlink:title="lag">
-            <rect x="327" y="79" width="38" height="32"/>
-            <rect x="325" y="77" width="38" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="335" y="97">lag</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#lagAmount" xlink:title="lagAmount">
-            <rect x="385" y="79" width="88" height="32"/>
-            <rect x="383" y="77" width="88" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="393" y="97">lagAmount</text></a><rect x="513" y="47" width="56" height="32" rx="10"/>
-         <rect x="511" y="45" width="56" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="521" y="65">INTO</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#tableName" xlink:title="tableName">
-            <rect x="589" y="47" width="88" height="32"/>
-            <rect x="587" y="45" width="88" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="597" y="65">tableName</text></a><rect x="717" y="47" width="26" height="32" rx="10"/>
-         <rect x="715" y="45" width="26" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="725" y="65">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#columnName" xlink:title="columnName">
-            <rect x="783" y="47" width="102" height="32"/>
-            <rect x="781" y="45" width="102" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="791" y="65">columnName</text></a><rect x="783" y="3" width="24" height="32" rx="10"/>
-         <rect x="781" y="1" width="24" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="791" y="21">,</text>
-         <rect x="925" y="47" width="26" height="32" rx="10"/>
-         <rect x="923" y="45" width="26" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="933" y="65">)</text>
-         <rect x="667" y="189" width="72" height="32" rx="10"/>
-         <rect x="665" y="187" width="72" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="675" y="207">VALUES</text>
-         <rect x="759" y="189" width="26" height="32" rx="10"/>
-         <rect x="757" y="187" width="26" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="767" y="207">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#value" xlink:title="value">
-            <rect x="825" y="189" width="54" height="32"/>
-            <rect x="823" y="187" width="54" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="833" y="207">value</text></a><rect x="825" y="145" width="24" height="32" rx="10"/>
-         <rect x="823" y="143" width="24" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="833" y="163">,</text>
-         <rect x="919" y="189" width="26" height="32" rx="10"/>
-         <rect x="917" y="187" width="26" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="927" y="207">)</text>
-         <rect x="667" y="233" width="70" height="32" rx="10"/>
-         <rect x="665" y="231" width="70" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="675" y="251">SELECT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#queryDef" xlink:title="queryDef">
-            <rect x="757" y="233" width="78" height="32"/>
-            <rect x="755" y="231" width="78" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="765" y="251">queryDef</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 61 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h342 m-372 0 h20 m352 0 h20 m-392 0 q10 0 10 10 m372 0 q0 -10 10 -10 m-382 10 v12 m372 0 v-12 m-372 12 q0 10 10 10 m352 0 q10 0 10 -10 m-362 10 h10 m54 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m88 0 h10 m20 -32 h10 m56 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m102 0 h10 m-142 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m122 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-122 0 h10 m24 0 h10 m0 0 h78 m20 44 h10 m26 0 h10 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v14 m274 0 v-14 m-274 14 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m0 0 h244 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-368 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m72 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m54 0 h10 m-94 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m74 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-74 0 h10 m24 0 h10 m0 0 h30 m20 44 h10 m26 0 h10 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m70 0 h10 m0 0 h10 m78 0 h10 m0 0 h110 m23 -44 h-3"/>
-         <polygon points="983 203 991 199 991 207"/>
-         <polygon points="983 203 975 199 975 207"/></svg>
+        <polygon points="9 17 1 13 1 21"/>
+         <polygon points="17 17 9 13 9 21"/>
+         <rect x="31" y="3" width="70" height="32" rx="10"/>
+         <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="39" y="21">INSERT</text>
+         <rect x="141" y="35" width="56" height="32" rx="10"/>
+         <rect x="139" y="33" width="56" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="149" y="53">batch</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#batchCount" xlink:title="batchCount">
+            <rect x="217" y="35" width="92" height="32"/>
+            <rect x="215" y="33" width="92" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="225" y="53">batchCount</text></a><rect x="329" y="35" width="94" height="32" rx="10"/>
+         <rect x="327" y="33" width="94" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="337" y="53">commitLag</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#n" xlink:title="n">
+            <rect x="443" y="35" width="28" height="32"/>
+            <rect x="441" y="33" width="28" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="451" y="53">n</text></a><rect x="511" y="35" width="36" height="32" rx="10"/>
+         <rect x="509" y="33" width="36" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="519" y="53">us</text>
+         <rect x="511" y="79" width="26" height="32" rx="10"/>
+         <rect x="509" y="77" width="26" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="519" y="97">s</text>
+         <rect x="511" y="123" width="32" height="32" rx="10"/>
+         <rect x="509" y="121" width="32" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="519" y="141">m</text>
+         <rect x="511" y="167" width="28" height="32" rx="10"/>
+         <rect x="509" y="165" width="28" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="519" y="185">h</text>
+         <rect x="511" y="211" width="28" height="32" rx="10"/>
+         <rect x="509" y="209" width="28" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="519" y="229">d</text>
+         <rect x="607" y="3" width="56" height="32" rx="10"/>
+         <rect x="605" y="1" width="56" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="615" y="21">INTO</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#tableName" xlink:title="tableName">
+            <rect x="683" y="3" width="88" height="32"/>
+            <rect x="681" y="1" width="88" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="691" y="21">tableName</text></a><rect x="173" y="321" width="26" height="32" rx="10"/>
+         <rect x="171" y="319" width="26" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="181" y="339">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#columnName" xlink:title="columnName">
+            <rect x="239" y="321" width="102" height="32"/>
+            <rect x="237" y="319" width="102" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="247" y="339">columnName</text></a><rect x="239" y="277" width="24" height="32" rx="10"/>
+         <rect x="237" y="275" width="24" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="247" y="295">,</text>
+         <rect x="381" y="321" width="26" height="32" rx="10"/>
+         <rect x="379" y="319" width="26" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="389" y="339">)</text>
+         <rect x="467" y="321" width="72" height="32" rx="10"/>
+         <rect x="465" y="319" width="72" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="475" y="339">VALUES</text>
+         <rect x="559" y="321" width="26" height="32" rx="10"/>
+         <rect x="557" y="319" width="26" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="567" y="339">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#value" xlink:title="value">
+            <rect x="625" y="321" width="54" height="32"/>
+            <rect x="623" y="319" width="54" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="633" y="339">value</text></a><rect x="625" y="277" width="24" height="32" rx="10"/>
+         <rect x="623" y="275" width="24" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="633" y="295">,</text>
+         <rect x="719" y="321" width="26" height="32" rx="10"/>
+         <rect x="717" y="319" width="26" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="727" y="339">)</text>
+         <rect x="467" y="365" width="70" height="32" rx="10"/>
+         <rect x="465" y="363" width="70" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="475" y="383">SELECT</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#queryDef" xlink:title="queryDef">
+            <rect x="557" y="365" width="78" height="32"/>
+            <rect x="555" y="363" width="78" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="565" y="383">queryDef</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h436 m-466 0 h20 m446 0 h20 m-486 0 q10 0 10 10 m466 0 q0 -10 10 -10 m-476 10 v12 m466 0 v-12 m-466 12 q0 10 10 10 m446 0 q10 0 10 -10 m-456 10 h10 m56 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m28 0 h10 m20 0 h10 m36 0 h10 m-76 0 h20 m56 0 h20 m-96 0 q10 0 10 10 m76 0 q0 -10 10 -10 m-86 10 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m26 0 h10 m0 0 h10 m-66 -10 v20 m76 0 v-20 m-76 20 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m32 0 h10 m0 0 h4 m-66 -10 v20 m76 0 v-20 m-76 20 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m28 0 h10 m0 0 h8 m-66 -10 v20 m76 0 v-20 m-76 20 v24 m76 0 v-24 m-76 24 q0 10 10 10 m56 0 q10 0 10 -10 m-66 10 h10 m28 0 h10 m0 0 h8 m40 -208 h10 m56 0 h10 m0 0 h10 m88 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-662 318 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m102 0 h10 m-142 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m122 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-122 0 h10 m24 0 h10 m0 0 h78 m20 44 h10 m26 0 h10 m-274 0 h20 m254 0 h20 m-294 0 q10 0 10 10 m274 0 q0 -10 10 -10 m-284 10 v14 m274 0 v-14 m-274 14 q0 10 10 10 m254 0 q10 0 10 -10 m-264 10 h10 m0 0 h244 m40 -34 h10 m72 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m54 0 h10 m-94 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m74 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-74 0 h10 m24 0 h10 m0 0 h30 m20 44 h10 m26 0 h10 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m70 0 h10 m0 0 h10 m78 0 h10 m0 0 h110 m23 -44 h-3"/>
+         <polygon points="783 335 791 331 791 339"/>
+         <polygon points="783 335 775 331 775 339"/></svg>


### PR DESCRIPTION
__Additions:__
* `first(sym_col)` first value in a symbol column
* `last(sym_col)` last value in a symbol column


__Changes:__
* `lag` as table parameter is now `commitLag`, examples and railroad diagrams now reflect this change
  *  Lag takes `n*units` where `units` may be `us`, `s`, `h`, `d`, e.g.:
  ```sql
     INSERT batch 100000 commitLag 180s INTO table
     ```