### PR TITLE
chore: use theme's default secondary button style

### DIFF
--- a/src/theme/Navbar/index.tsx
+++ b/src/theme/Navbar/index.tsx
@@ -123,6 +123,7 @@ function Navbar(): JSX.Element {
             className={styles.benchmarkButton}
             size="xsmall"
             to="/time-series-benchmark-suite/"
+            variant="secondary"
           >
             Benchmark
           </Button>

--- a/src/theme/Navbar/styles.module.css
+++ b/src/theme/Navbar/styles.module.css
@@ -5,7 +5,6 @@
 
 .benchmarkButton {
   margin-left: 10px;
-  text-transform: none;
 }
 
 .brand {

--- a/src/theme/Navbar/styles.module.css
+++ b/src/theme/Navbar/styles.module.css
@@ -5,14 +5,7 @@
 
 .benchmarkButton {
   margin-left: 10px;
-  background-color: transparent;
-  border: 2px solid #7a7a80;
-  color: var(--palette-white);
   text-transform: none;
-}
-
-.benchmarkButton:hover {
-  background-color: var(--palette-white-20);
 }
 
 .brand {


### PR DESCRIPTION
Minor edit to the nav button to use the default `secondary` button style instead of hand-written values