### PR TITLE
chore: disable caching node assets

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,11 +2,3 @@
   base = "/"
   command = "yarn build"
   publish = "build"
-
-[[plugins]]
-  package = "netlify-plugin-cache"
-  [plugins.inputs]
-    paths = [
-      "node_modules/.cache",
-    ]
-


### PR DESCRIPTION
Currently, webpack cache on Netlify has older build vars which are not being updated, this PR disables caching of `node_modules/.cache` to trigger a full build