### PR TITLE
chore(docs): clean up ILP prop names and their defaults

### DIFF
--- a/docs/operations/capacity-planning.md
+++ b/docs/operations/capacity-planning.md
@@ -205,7 +205,7 @@ if either:
 
 ```bash title="server.conf"
 # commit when this number of uncommitted records is reached
-line.tcp.max.uncommitted.rows=1000
+cairo.max.uncommitted.rows=1000
 # commit uncommitted rows when this timer is reached
 line.tcp.maintenance.job.interval=1000
 ```

--- a/docs/reference/api/influxdb.md
+++ b/docs/reference/api/influxdb.md
@@ -134,8 +134,8 @@ busiest worker thread will be reassigned to the least busy worker thread.
 
 Uncommitted rows are committed either:
 
-- after `line.tcp.maintenance.job.hysterisis.in.ms` milliseconds have passed
-- once reaching `line.tcp.max.uncommitted.rows` uncommitted rows.
+- after `line.tcp.maintenance.job.interval` milliseconds have passed
+- once reaching `cairo.max.uncommitted.rows` uncommitted rows.
 
 ### Configuration
 
@@ -170,9 +170,9 @@ QuestDB to listen for `unicast`.
 
 Uncommitted rows are committed either:
 
+- after `line.tcp.maintenance.job.interval` milliseconds have passed
 - after receiving a number of continuous messages equal to
-  `line.udp.commit.rate`
-- when messages are no longer being received
+  `line.udp.commit.rate` or `cairo.max.uncommitted.rows` whichever is smaller.
 
 ### Configuration
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -164,8 +164,8 @@ writer threads in a QuestDB instance.
 | ----------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | line.tcp.n.updates.per.load.balance | 10000   | Maximum number of updates in a given table since the last load balancing before triggering a new load balancing job.                             |
 | line.tcp.max.load.ratio             | 1.9     | Maximum load ratio (max loaded worker/min loaded worker) before QuestDB will attempt to rebalance the load between the writer workers.           |
-| line.tcp.max.uncommitted.rows       | 1000    | Maximum number of uncommitted rows, note that rows will always be committed if they have been received line.tcp.maintenance.job.interval ms ago. |
-| line.tcp.maintenance.job.interval   | 1000    | Maximum amount of time in between maintenance jobs, these will commit any uncommitted data.                                                      |
+| cairo.max.uncommitted.rows          | 500000  | Maximum number of uncommitted rows, note that rows will always be committed if they have been received line.tcp.maintenance.job.interval ms ago. |
+| line.tcp.maintenance.job.interval   | 30000   | Maximum amount of time (in milliseconds) between maintenance jobs, these will commit any uncommitted data.                                       |
 
 ### Minimal HTTP server
 


### PR DESCRIPTION
Removes/updates obsolete prop names in ILP docs and updates the defaults to actual values.