### PR TITLE
Request to update typo

### DIFF
--- a/docs/reference/command-line-options.md
+++ b/docs/reference/command-line-options.md
@@ -67,7 +67,7 @@ questdb.exe [start|stop|status|install|remove] \
 | Option | Description                                                                                                                                                                                                          |
 | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-d`   | Expects a `dir` directory value which is a folder that will be used as QuestDB's root directory. For more information and the default values, see the [default root](#default-root-directory) section below.         |
-| `-t`   | Expects a `tag` string value which will be as a tag for the service. This option allows users to run several QuestDB services and manage them separately. If this option omitted, the default tag will be `questdb`. |
+| `-t`   | Expects a `tag` string value which will be as a tag for the service. This option allows users to run several QuestDB services and manage them separately. If this option is omitted, the default tag will be `questdb`. |
 | `-f`   | Force re-deploying the Web Console. Without this option, the Web Console is cached and deployed only when missing.                                                                                                   |
 | `-j`   | **Windows only!** This option allows to specify a path to `JAVA_HOME`.                                                                                                                                               |
 


### PR DESCRIPTION
In the 'https://questdb.io/docs/reference/command-line-options/' page, in the first table, in the description of Option '-t',  it we can replace 'If this option omitted' with 'if this option is omitted'. If you agree, please feel free to update.

- Current: If this option omitted.
- Suggestion: If this option is omitted. (I added 'is' to the sentence).

Thanks,
Pradeep.