### PR TITLE
Request to update Release Notes link

### DIFF
--- a/blog/2022-01-27-release-sql-jit-compiler.md
+++ b/blog/2022-01-27-release-sql-jit-compiler.md
@@ -208,7 +208,7 @@ working on replication, further JIT-compiled filter performance improvements,
 and more.
 
 We hope you enjoyed the features and functionality in version 6.2. See the
-[release notes on GitHub](https://github.com/questdb/questdb/releases/tag/6.2.0)
+[release notes on GitHub](https://github.com/questdb/questdb/releases/tag/6.2)
 for the complete list of additions and fixes. We’re eagerly awaiting your
 feedback, so feel free to reach out and let us know how it's running. You can
 let us know how we're doing or just come by and say hello

--- a/blog/2022-01-27-release-sql-jit-compiler.md
+++ b/blog/2022-01-27-release-sql-jit-compiler.md
@@ -208,7 +208,7 @@ working on replication, further JIT-compiled filter performance improvements,
 and more.
 
 We hope you enjoyed the features and functionality in version 6.2. See the
-[release notes on GitHub](https://github.com/questdb/questdb/releases/tag/6.2)
+[release notes on GitHub](https://github.com/questdb/questdb/releases/tag/6.2) 
 for the complete list of additions and fixes. We’re eagerly awaiting your
 feedback, so feel free to reach out and let us know how it's running. You can
 let us know how we're doing or just come by and say hello


### PR DESCRIPTION
In the last paragraph of the 'QuestDB 6.2 January release, SQL JIT compiler' page (https://questdb.io/blog/2022/01/27/release-sql-jit-compiler/), the 'release notes on GitHub' link is not working. If the suggested link is correct, please accept the update. Else, pls suggest the correct link, and I will update it.

- Current link: https://github.com/questdb/questdb/releases/tag/6.2.0
- Suggested link: https://github.com/questdb/questdb/releases/tag/6.2

