### PR TITLE
Request to update LATEST BY to LATEST ON

### DIFF
--- a/blog/2022-01-27-release-sql-jit-compiler.md
+++ b/blog/2022-01-27-release-sql-jit-compiler.md
@@ -208,7 +208,7 @@ working on replication, further JIT-compiled filter performance improvements,
 and more.
 
 We hope you enjoyed the features and functionality in version 6.2. See the
-[release notes on GitHub](https://github.com/questdb/questdb/releases/tag/6.2.0)
+[release notes on GitHub](https://github.com/questdb/questdb/releases/tag/6.2)
 for the complete list of additions and fixes. We’re eagerly awaiting your
 feedback, so feel free to reach out and let us know how it's running. You can
 let us know how we're doing or just come by and say hello

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -158,7 +158,7 @@ when starting services:
 - [GROUP BY](/docs/reference/sql/group-by/)
 - [INSERT](/docs/reference/sql/insert/)
 - [JOIN](/docs/reference/sql/join/)
-- [LATEST BY](/docs/reference/sql/latest-on/)
+- [LATEST ON](/docs/reference/sql/latest-on/)
 - [LIMIT](/docs/reference/sql/limit/)
 - [ORDER BY](/docs/reference/sql/order-by/)
 - [RENAME TABLE](/docs/reference/sql/rename/)


### PR DESCRIPTION
In the Introduction page (https://questdb.io/docs/introduction/), 'LATEST BY' leads to 'LATEST ON' command information. Also, I read that 'LATEST BY' is deprecated. So, I updated the link text. Pls accept if you agree with this action.