### PR TITLE
docs: Update Release Notes information

### DIFF
--- a/blog/2022-01-27-release-sql-jit-compiler.md
+++ b/blog/2022-01-27-release-sql-jit-compiler.md
@@ -208,7 +208,7 @@ working on replication, further JIT-compiled filter performance improvements,
 and more.
 
 We hope you enjoyed the features and functionality in version 6.2. See the
-[release notes on GitHub](https://github.com/questdb/questdb/releases/tag/6.2.0)
+[release notes on GitHub](https://github.com/questdb/questdb/releases/tag/6.2)
 for the complete list of additions and fixes. We’re eagerly awaiting your
 feedback, so feel free to reach out and let us know how it's running. You can
 let us know how we're doing or just come by and say hello

--- a/blog/2022-01-27-release-sql-jit-compiler.md
+++ b/blog/2022-01-27-release-sql-jit-compiler.md
@@ -97,18 +97,18 @@ For more information on the JIT compiler, refer to this
 
 ## New LATEST BY syntax and improvements
 
-The database now supports a new syntax for LATEST BY clause:
+The LATEST BY syntax is deprecated, and the database now supports a new syntax called LATEST ON:
 
 ```sql
 SELECT * FROM tab WHERE x > 0
 LATEST ON timestamp PARTITION BY y;
 ```
 
-This syntax makes the LATEST BY clause consistent with the query execution order
-since LATEST BY now must follow the WHERE clause. Release 6.2 also includes a
-number of fixes to make sure that the WHERE always gets applied before the
-LATEST BY. For more details on the new syntax, see the
-[LATEST BY documentation](/docs/reference/sql/latest-on/).
+This syntax makes the LATEST ON clause consistent with the query execution order
+since LATEST ON now must follow the WHERE clause. Release 6.2 also includes a
+number of fixes to make sure that the WHERE clause always gets applied before the
+LATEST ON. For more details on the new syntax, see the
+[LATEST ON documentation](/docs/reference/sql/latest-on/).
 
 ## Optimize LIMIT SQL queries
 

--- a/blog/2022-01-27-release-sql-jit-compiler.md
+++ b/blog/2022-01-27-release-sql-jit-compiler.md
@@ -105,8 +105,8 @@ LATEST ON timestamp PARTITION BY y;
 ```
 
 This syntax makes the LATEST ON clause consistent with the query execution order
-since LATEST ON now must follow the WHERE clause. Release 6.2 also includes a
-number of fixes to make sure that the WHERE clause always gets applied before the
+since LATEST ON follows the WHERE clause. Release 6.2 also includes a
+number of fixes to ensure that the WHERE clause always gets applied before
 LATEST ON. For more details on the new syntax, see the
 [LATEST ON documentation](/docs/reference/sql/latest-on/).
 


### PR DESCRIPTION
Update incorrect link and clearly mention that LATEST BY is deprecated and LATEST ON should be used.