### PR TITLE
[docs] Capture `power()` in docs/function/numeric

### DIFF
--- a/docs/reference/function/numeric.md
+++ b/docs/reference/function/numeric.md
@@ -60,6 +60,30 @@ SELECT log(4.123)
 | ------------ |
 | 1.4165810537 |
 
+## power
+
+`power(base, exponent)` returns the value of a number `base` raised to the
+power of some number `exponent`.
+
+**Arguments:**
+
+- `base` is any numeric value.
+- `exponent` is any numeric value.
+
+**Return value:**
+
+Return value type is `double`.
+
+**Examples:**
+
+```questdb-sql
+SELECT power(2, 3)
+```
+
+| power |
+| ----- |
+| 8     |
+
 ## round
 
 `round(value, scale)` returns the **closest** value in the specified scale. It

--- a/docs/reference/function/numeric.md
+++ b/docs/reference/function/numeric.md
@@ -63,7 +63,7 @@ SELECT log(4.123)
 ## power
 
 `power(base, exponent)` returns the value of a number `base` raised to the
-power of some number `exponent`.
+power defined by `exponent`.
 
 **Arguments:**
 

--- a/docs/reference/function/numeric.md
+++ b/docs/reference/function/numeric.md
@@ -77,7 +77,7 @@ Return value type is `double`.
 **Examples:**
 
 ```questdb-sql
-SELECT power(2, 3)
+SELECT power(2, 3);
 ```
 
 | power |


### PR DESCRIPTION
Adds documentation for `power()` function along with relevant examples in the relevant section. 
Tested on local development setup.

Closes #1082.

![image](https://user-images.githubusercontent.com/11232940/193440156-02b2a1ec-0903-4131-aad2-10217b86b946.png)