### PR TITLE
chore(ui): move `popular topics` on `/blog` page to a sidebar

### DIFF
--- a/src/theme/BlogListPage/Categories/styles.module.css
+++ b/src/theme/BlogListPage/Categories/styles.module.css
@@ -1,23 +1,11 @@
 .root {
   --title-color: var(--palette-pink);
-  --cols: 1;
-
-  display: grid;
-  grid-template-columns: repeat(var(--cols), 1fr);
-  gap: 1rem;
+  --gap: 1rem;
+  --col-width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gap);
   margin-bottom: 2rem;
-}
-
-@media screen and (min-width: 470px) {
-  .root {
-    --cols: 2;
-  }
-}
-
-@media screen and (min-width: 750px) {
-  .root {
-    --cols: 4;
-  }
 }
 
 .category {
@@ -25,6 +13,13 @@
   padding: 1.3rem 1.3rem 1.8rem;
   border: 1px solid var(--theme-card-border-color);
   border-radius: 15px;
+  flex: 1 0 calc(50% - var(--gap));
+}
+
+@media screen and (min-width: 900px) {
+  .category {
+    flex-basis: 100%;
+  }
 }
 
 .category:hover,

--- a/src/theme/BlogListPage/Chips/index.tsx
+++ b/src/theme/BlogListPage/Chips/index.tsx
@@ -16,6 +16,7 @@ export const Chips = ({ items, activeChip }: Props) => (
         key={permalink}
         className={styles.chip}
         label={name}
+        size="medium"
         permalink={ensureTrailingSlash(permalink)}
         active={activeChip === permalink}
       />

--- a/src/theme/BlogListPage/Chips/styles.module.css
+++ b/src/theme/BlogListPage/Chips/styles.module.css
@@ -1,13 +1,17 @@
 .root {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 0.5rem;
   margin-bottom: 5rem;
+  align-items: center;
 }
 
 .chip {
-  margin-bottom: 1rem;
-  margin-right: 1rem;
+  padding: 0.4rem 0.8rem;
 }
 
 .linkToTags,
 .linkToTags:hover {
+  padding: 0 0 0 0.5rem;
   color: var(--palette-pink);
 }

--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -104,68 +104,74 @@ function BlogListPage(props: Props): JSX.Element {
         tag: "blog_posts_list",
       }}
     >
-      <main className={styles.root}>
-        {latestPost !== undefined && (
-          <div className={styles.latestPost}>
-            <BlogPostItem
-              key={latestPost.content.metadata.permalink}
-              frontMatter={latestPost.content.frontMatter}
-              metadata={{
-                ...latestPost.content.metadata,
-                permalink: ensureTrailingSlash(
-                  (latestPost.content.frontMatter as FrontMatter).permalink ??
-                    latestPost.content.metadata.permalink,
-                ),
-                tags: [],
-              }}
-              truncated={latestPost.content.metadata.truncated}
-            >
-              {React.createElement(latestPost.content)}
-            </BlogPostItem>
+      <div className={styles.root}>
+        <main>
+          {latestPost !== undefined && (
+            <div className={styles.latestPost}>
+              <BlogPostItem
+                key={latestPost.content.metadata.permalink}
+                frontMatter={latestPost.content.frontMatter}
+                metadata={{
+                  ...latestPost.content.metadata,
+                  permalink: ensureTrailingSlash(
+                    (latestPost.content.frontMatter as FrontMatter).permalink ??
+                      latestPost.content.metadata.permalink,
+                  ),
+                  tags: [],
+                }}
+                truncated={latestPost.content.metadata.truncated}
+              >
+                {React.createElement(latestPost.content)}
+              </BlogPostItem>
+            </div>
+          )}
+
+          {isTagsPage ? (
+            <h1 className={styles.title}>
+              Articles about{" "}
+              <span className={styles.tag}>
+                {((metadata as unknown) as Tag).name}
+              </span>
+            </h1>
+          ) : (
+            <h2 className={styles.title}>Earlier Posts</h2>
+          )}
+
+          <div className={styles.posts}>
+            {posts.map(({ content }, i) => (
+              <ListItem
+                key={content.metadata.permalink}
+                content={content}
+                belowFold={i > 5}
+                forcedTag={
+                  isTagsPage
+                    ? {
+                        label: ((metadata as unknown) as Tag).name,
+                        permalink: ensureTrailingSlash(metadata.permalink),
+                      }
+                    : undefined
+                }
+              />
+            ))}
           </div>
-        )}
 
-        <h2>Popular topics</h2>
-        {/* BlogListPage component is used for `blog/` and also for `blog/tags/*`.
+          <BlogListPaginator metadata={metadata} />
+        </main>
+
+        <aside className={styles.categories}>
+          <h2>Popular topics</h2>
+          {/* BlogListPage component is used for `blog/` and also for `blog/tags/*`.
             When rendered for `blog/tags/*, then `metadata` includes tag, instead of blog data */}
-        <Categories
-          activeCategory={((metadata as unknown) as Tag).permalink}
-          categories={categories}
-        />
-        <Chips
-          activeChip={((metadata as unknown) as Tag).permalink}
-          items={prioritizedTags}
-        />
-
-        {isTagsPage ? (
-          <h1 className={styles.tagsTitle}>
-            Articles tagged with &quot;{((metadata as unknown) as Tag).name}
-            &quot;
-          </h1>
-        ) : (
-          <h2>Blog Posts</h2>
-        )}
-
-        <div className={styles.posts}>
-          {posts.map(({ content }, i) => (
-            <ListItem
-              key={content.metadata.permalink}
-              content={content}
-              belowFold={i > 5}
-              forcedTag={
-                isTagsPage
-                  ? {
-                      label: ((metadata as unknown) as Tag).name,
-                      permalink: ensureTrailingSlash(metadata.permalink),
-                    }
-                  : undefined
-              }
-            />
-          ))}
-        </div>
-
-        <BlogListPaginator metadata={metadata} />
-      </main>
+          <Categories
+            activeCategory={((metadata as unknown) as Tag).permalink}
+            categories={categories}
+          />
+          <Chips
+            activeChip={((metadata as unknown) as Tag).permalink}
+            items={prioritizedTags}
+          />
+        </aside>
+      </div>
     </Layout>
   )
 }

--- a/src/theme/BlogListPage/styles.module.css
+++ b/src/theme/BlogListPage/styles.module.css
@@ -4,9 +4,22 @@
   padding: 0 1rem;
 }
 
+.latestPost {
+  margin-bottom: 8rem;
+}
+
+.title {
+  margin-bottom: 4rem;
+}
+
+.tag {
+  color: var(--palette-pink);
+}
+
 .posts {
   --cols: 1;
   --gap: 4rem;
+  grid-area: posts;
   display: grid;
   grid-template-columns: 1fr;
   grid-template-columns: repeat(var(--cols), 1fr);
@@ -24,20 +37,15 @@
 @media screen and (min-width: 900px) {
   .root {
     margin-top: 5rem;
-  }
-
-  .latestPost {
-    padding: 0 5rem;
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: 3fr minmax(100px, 1fr);
   }
 
   .posts {
-    --cols: 3;
+    --cols: 2;
     --gap: 4rem 2rem;
   }
-}
-
-.tagsTitle {
-  font-size: var(--ifm-h2-font-size);
 }
 
 .tags {


### PR DESCRIPTION
This PR slightly restructures pages on `/blog` and `/blog/tags/*`.

Users who navigate to blog tags page, first see "popular topics"
section. This is a problem, because users who go to blog tags page
expect to see a list of specific blog posts. Instead, they first see a
list of categories and only then a list of blog posts.

This is especially a big problem on mobile: users need to scroll through
a whole list of categories before they see a list of blog posts.

## before `/blog`

<img width="1305" alt="Screenshot 2023-02-06 at 16 05 23" src="https://user-images.githubusercontent.com/4284659/216992190-c517da5e-b7ff-4a6b-b851-a4b39cdb951b.png">

## after `/blog`

<img width="1268" alt="Screenshot 2023-02-06 at 16 06 09" src="https://user-images.githubusercontent.com/4284659/216992544-3f4253b1-8e33-470f-a7ec-eede0bb771d3.png">

## before `/blog/tags/benchmarks/`

<img width="1235" alt="Screenshot 2023-02-06 at 16 07 36" src="https://user-images.githubusercontent.com/4284659/216992641-11322e05-5f7c-4c2d-9782-494992643cd5.png">

## after `/blog/tags/benchmarks/`

<img width="1237" alt="Screenshot 2023-02-06 at 16 08 06" src="https://user-images.githubusercontent.com/4284659/216992783-a0966178-25fb-4fe2-9b78-2e45d1fc773d.png">

## before `/blog/tags/benchmarks/` on mobile

relevant content is not visible at all, unless user scrolls (a lot)

<img width="444" alt="Screenshot 2023-02-06 at 16 09 55" src="https://user-images.githubusercontent.com/4284659/216993181-572f7e06-bc55-4f1d-afd8-0f55a44ebb55.png">


## after `/blog/tags/benchmarks/` on mobile

<img width="431" alt="Screenshot 2023-02-06 at 16 08 48" src="https://user-images.githubusercontent.com/4284659/216993065-83c654aa-29ca-4c21-8686-f1992cdc3f7a.png">
