### PR TITLE
docs: correct spelling of resources

### DIFF
--- a/docs/reference/sql/order-by.md
+++ b/docs/reference/sql/order-by.md
@@ -26,7 +26,7 @@ ratings ORDER BY userId DESC;
 ratings ORDER BY userId, rating DESC;
 ```
 
-## Ressources management
+## Resource management
 
 :::caution
 


### PR DESCRIPTION
I didn't bother with creating an issue for this typo... hopefully that's OK.
"Ressources" is the French spelling of "Resources". Also, typically in English it would be treated as an adjective, so it wouldn't be plural.