### PR TITLE
chore(docs): fixing tsx format

### DIFF
--- a/src/modules/integration/index.tsx
+++ b/src/modules/integration/index.tsx
@@ -66,8 +66,7 @@ const integrations: Array<{
   {
     logo: { ...logos.redpanda, width: 50, svg: RedpandaLogo },
     label: "Redpanda",
-    src:
-      "/docs/third-party-tools/redpanda/",
+    src: "/docs/third-party-tools/redpanda/",
   },
   {
     logo: { ...logos.plotly, svg: PlotlyLogo },


### PR DESCRIPTION
I seem to introduce some problems in https://github.com/questdb/questdb.io/pull/1404

I found this warning:

```
Issues checking in progress...
WARNING in src/modules/integration/index.tsx:69:9
prettier/prettier: Delete `⏎·····`
    67 |     logo: { ...logos.redpanda, width: 50, svg: RedpandaLogo },
    68 |     label: "Redpanda",
  > 69 |     src:
       |         ^
  > 70 |       "/docs/third-party-tools/redpanda/",
       | ^^^^^^
    71 |   },
    72 |   {
    73 |     logo: { ...logos.plotly, svg: PlotlyLogo },
```

This PR attempts to fix it.