### PR TITLE
Corrects the spelling error in HomePage for `Why time series?` sections

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,7 +44,7 @@ const Cards = () => (
           {
             header: "Network traffic analysis",
             content:
-              "Collect sFlow or other network traffic metadata to run analytics and detect anomalies in real-time.",
+              "Collects Flow or other network traffic metadata to run analytics and detect anomalies in real-time.",
           },
 
           {


### PR DESCRIPTION
<img width="586" alt="Screenshot 2023-04-07 at 3 10 38 AM" src="https://user-images.githubusercontent.com/17192467/230499106-2abe7810-7135-4273-9c20-4d7a3a9c8ad2.png">
