### PR TITLE
fixed overflowing tables at quest db cloud page

### DIFF
--- a/src/modules/cloud/CompareFeatures/index.tsx
+++ b/src/modules/cloud/CompareFeatures/index.tsx
@@ -170,7 +170,7 @@ export const CompareFeatures = () => {
         Features
       </Section.Title>
 
-      <Section>
+      <Section noGap>
         <div className={style.tables}>
           <FeatureTable title="Core features" items={CoreFeaturesItems} />
 

--- a/src/modules/cloud/FeatureTable/styles.module.css
+++ b/src/modules/cloud/FeatureTable/styles.module.css
@@ -19,12 +19,6 @@
   font-weight: var(--ifm-font-weight-bold);
 }
 
-@media (max-width: 400px) {
-  .root thead th {
-    padding: 0rem;
-  }
-}
-
 .root thead th:first-child {
   text-align: left;
   width: var(--first-col-width);

--- a/src/modules/cloud/FeatureTable/styles.module.css
+++ b/src/modules/cloud/FeatureTable/styles.module.css
@@ -19,6 +19,12 @@
   font-weight: var(--ifm-font-weight-bold);
 }
 
+@media (max-width: 400px) {
+  .root thead th {
+    padding: 0rem;
+  }
+}
+
 .root thead th:first-child {
   text-align: left;
   width: var(--first-col-width);


### PR DESCRIPTION
fixed overflowing tables at quest db cloud page. 
**before:**
![Screen Shot 2023-04-15 at 4 45 23 PM](https://user-images.githubusercontent.com/98866798/232210786-e67e5173-69f1-42df-9124-c6fcc0a99160.png)
**after:**
![Screen Shot 2023-04-15 at 4 50 28 PM](https://user-images.githubusercontent.com/98866798/232210843-8ea5a5c1-8446-4872-b393-aebfed4fc18f.png)
At smaller screen sizes (bellow 400px) the tables are overflowing due to some padding issue. i fixed it by removing the extra padding