### PR TITLE
image overflow at swag page

### DIFF
--- a/src/css/community/page.module.css
+++ b/src/css/community/page.module.css
@@ -11,6 +11,9 @@
   .flex {
     flex-wrap: nowrap;
   }
+  .section_image {
+    max-width: 400px;
+  }
 }
 
 .section__title {
@@ -87,7 +90,7 @@ html[data-theme="light"] .contribution_link img {
 }
 
 .section_image {
-  max-width: 400px;
+  max-width: 300px;
   width: auto;
   height: auto;
   margin: 0 auto;

--- a/src/css/community/page.module.css
+++ b/src/css/community/page.module.css
@@ -11,9 +11,6 @@
   .flex {
     flex-wrap: nowrap;
   }
-  .section_image {
-    max-width: 400px;
-  }
 }
 
 .section__title {
@@ -94,6 +91,12 @@ html[data-theme="light"] .contribution_link img {
   width: auto;
   height: auto;
   margin: 0 auto;
+}
+
+@media (min-width: 400px) {
+  .section_image {
+    max-width: 400px;
+  }
 }
 
 .howToContribute {

--- a/src/css/community/page.module.css
+++ b/src/css/community/page.module.css
@@ -87,16 +87,10 @@ html[data-theme="light"] .contribution_link img {
 }
 
 .section_image {
-  max-width: 300px;
+  max-width: 100%;
   width: auto;
   height: auto;
   margin: 0 auto;
-}
-
-@media (min-width: 400px) {
-  .section_image {
-    max-width: 400px;
-  }
 }
 
 .howToContribute {

--- a/src/css/community/page.module.css
+++ b/src/css/community/page.module.css
@@ -87,10 +87,16 @@ html[data-theme="light"] .contribution_link img {
 }
 
 .section_image {
-  max-width: 100%;
+  max-width: 300px;
   width: auto;
   height: auto;
   margin: 0 auto;
+}
+
+@media (min-width: 400px) {
+  .section_image {
+    max-width: 400px;
+  }
 }
 
 .howToContribute {

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -107,8 +107,8 @@ const Community = () => (
             src="/img/pages/community/questdb-shirt.png"
             alt="A black t-shirt with the QuestDB logo printed on the front"
             className={paCss.section_image}
-            width={400}
-            height={400}
+            width={300}
+            height={300}
           />
 
           <div className={paCss.reward}>Get a QuestDB T-shirt!</div>

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -107,8 +107,8 @@ const Community = () => (
             src="/img/pages/community/questdb-shirt.png"
             alt="A black t-shirt with the QuestDB logo printed on the front"
             className={paCss.section_image}
-            width={300}
-            height={300}
+            width={400}
+            height={400}
           />
 
           <div className={paCss.reward}>Get a QuestDB T-shirt!</div>


### PR DESCRIPTION
what i did is changed the default size of the image to `300px` and at `min-width: 800px` i changed it to `400px`
**before:**
![Screen Shot 2023-04-19 at 10 28 39 PM](https://user-images.githubusercontent.com/98866798/233147959-91fb2d8b-2011-45ae-95de-828ed30ee71c.png)
**after:**
![Screen Shot 2023-04-19 at 10 28 57 PM](https://user-images.githubusercontent.com/98866798/233148011-441995d7-e2c8-4ebb-be95-f568043037bb.png)
